### PR TITLE
Release 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudfour/eslint-plugin",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudfour/eslint-plugin",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Cloud Four's shareable ESLint configuration",
   "author": "Cloud Four <info@cloudfour.com> (http://cloudfour.com)",
   "homepage": "https://github.com/cloudfour/eslint-config",


### PR DESCRIPTION
Release draft at https://github.com/cloudfour/eslint-config/releases

This is breaking because it enables rules that were not enabled before, and the package name is changed.

Once this is merged to `master`, I will run `npm publish`