### PR TITLE
Enable `no-unused-expressions` for ternaries and short-circuit

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -69,6 +69,14 @@ module.exports.configs = {
 
         // Overrides
         'valid-jsdoc': 'off',
+        'no-unused-expressions': [
+          'error',
+          {
+            allowShortCircuit: false,
+            allowTernary: false,
+            allowTaggedTemplates: false
+          }
+        ],
         'no-return-assign': ['error'],
         'func-names': 'off',
         'prefer-const': 'error',


### PR DESCRIPTION
See the discussion in https://github.com/cloudfour/eslint-config/issues/7

@Josh68 are you OK with this change?

This prevents code like:

```js
window.foo && causeSideEffects()
```

and

```js
window.foo ? asdf = 123 : sdfg = 234
```

In favor of:

```js
if (window.foo) {
  causeSideEffects()
}
```

and

```js
if (window.foo) {
  asdf = 123
} else {
  sdfg = 234
}
```

Should this cause a major version? It could be argued that enabling rules like this would cause a major version because code that previously passed will stop passing, but I'm not sure

Closes #7 