### PR TITLE
Update recommended setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Add this to your `package.json`:
 
 ```json
   "scripts": {
-    "check-lint": "prettier --list-different '**/*.js' && eslint '**/*.js'",
-    "lint": "prettier --write '**/*.js' && eslint --fix '**/*.js'"
+    "check-lint": "eslint '**/*.js' && prettier --check '**/*.js'",
+    "lint": "eslint --fix '**/*.js' && prettier --write '**/*.js'"
   },
   "eslintConfig": {
     "extends": "plugin:@cloudfour/recommended"
@@ -71,5 +71,5 @@ npm run lint
 
 This config relies on using a version of eslint installed locally to your project. If you also have eslint installed globally, it's possible to run into conflicts. To avoid any problems, either:
 
-* Just use the `npm run check-lint` and `npm run lint` scripts, which will run the local version of eslint.
-* Or, if you prefer to run eslint by hand, use [npx](https://www.npmjs.com/package/npx), which will run the local version of eslint. eg, `npx eslint '**/*.js'`
+- Just use the `npm run check-lint` and `npm run lint` scripts, which will run the local version of eslint.
+- Or, if you prefer to run eslint by hand, use [npx](https://www.npmjs.com/package/npx), which will run the local version of eslint. eg, `npx eslint '**/*.js'`

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Add this to your `package.json`:
 
 ```json
   "scripts": {
-    "check-lint": "eslint '**/*.js' && prettier --check '**/*.js'",
-    "lint": "eslint --fix '**/*.js' && prettier --write '**/*.js'"
+    "check-lint": "eslint . && prettier --check .",
+    "lint": "eslint --fix . && prettier --write ."
   },
   "eslintConfig": {
     "extends": "plugin:@cloudfour/recommended"

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "prettier": "2.0.2"
   },
   "scripts": {
-    "check-lint": "eslint . && prettier --list-different '**/*.js'",
-    "lint": "eslint --fix . && prettier --write '**/*.js'",
+    "check-lint": "eslint '**/*.js' && prettier --check '**/*.js'",
+    "lint": "eslint --fix '**/*.js' && prettier --write '**/*.js'",
     "prepublishOnly": "npm ci && npm run build && npm run check-lint",
     "postpublish": "git tag v$npm_package_version && git push --tags",
     "build": "node build.js",

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "prettier": "2.0.2"
   },
   "scripts": {
-    "check-lint": "eslint '**/*.js' && prettier --check '**/*.js'",
-    "lint": "eslint --fix '**/*.js' && prettier --write '**/*.js'",
+    "check-lint": "eslint . && prettier --check .",
+    "lint": "eslint --fix . && prettier --write .",
     "prepublishOnly": "npm ci && npm run build && npm run check-lint",
     "postpublish": "git tag v$npm_package_version && git push --tags",
     "build": "node build.js",

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,3 @@
 {
-  "extends": [
-    "config:base"
-  ]
+  "extends": ["config:base"]
 }


### PR DESCRIPTION
1. [Prettier now supports passing a directory to the cli to format all supported files in that directory](https://prettier.io/blog/2020/03/21/2.0.0.html#expand-directories-including--7660httpsgithubcomprettierprettierpull7660-by-thorn0httpsgithubcomthorn0). So I switched to using `.` instead of globs
2. A few days I found out that prettier [has a `--check` flag](https://prettier.io/blog/2019/01/20/1.16.0.html#add-a---check-flag-5629-by-kachkaev) that we can use instead of the `--list-different` flag. `--check` produces more helpful human-readable output
3. I switched the order of prettier and eslint, so eslint runs first, then prettier. The goal of this change is to prevent cases where you have to run `npm run lint` twice to get the desired output. Before, when prettier was running first, it was possible for prettier to run successfully on code, and then eslint to run afterwards and make non-formatting changes to the code that made it no longer match prettier formatting. Now that should not be a problem.
   Here is an example:

   Input code:
   ```js
   if (Boolean(asdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfa)) {
   }
   ```

   When you run it through prettier:
   ```js
   if (
     Boolean(asdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfa)
   ) {
   }
   ```

   Then through ESLint (`no-extra-boolean-cast` rule):
   ```js
   if (
     asdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfa
   ) {
   }
   ```
   At that point, prettier would want to shorten it to one line because it fits on one line. But since prettier was being run first, it didn't shorten it until `npm run lint` was run a second time.