### PR TITLE
Add JSDoc plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The plugins that this exposes are:
 - [`standard`](https://github.com/standard/eslint-plugin-standard)
 - [`promise`](https://github.com/xjamundx/eslint-plugin-promise)
 - [`unicorn`](https://github.com/sindresorhus/eslint-plugin-unicorn)
+- [`jsdoc`](https://github.com/gajus/eslint-plugin-jsdoc)
 
 To override settings for any of these plugins, you must prefix the configuration
 with `cloudfour/`, because the plugins are exposed through this "super-plugin".

--- a/fixtures/cloudfour.com-patterns/gulpfile.js/tasks/svg-to-twig.js
+++ b/fixtures/cloudfour.com-patterns/gulpfile.js/tasks/svg-to-twig.js
@@ -30,8 +30,8 @@ const dynamicSvgProps = [
  * Accepts SVG source markup and templatizes root attributes while also adding
  * layout blocks (`before`, `content` and `after`) to its contents.
  *
- * @param {String} src - The source SVG markup.
- * @returns {String}
+ * @param {string} src - The source SVG markup.
+ * @returns {string}
  */
 function templatizeSvgString(src) {
   const svg = ltx.parse(src);

--- a/fixtures/cloudfour.com-patterns/gulpfile.js/theo-formats/stories.mdx.js
+++ b/fixtures/cloudfour.com-patterns/gulpfile.js/theo-formats/stories.mdx.js
@@ -6,8 +6,8 @@ const { basename, extname } = require('path');
 /**
  * Return a string containing Storybook Docs MDX markup for a color.
  *
- * @param {Object} prop - Theo property
- * @returns {String}
+ * @param {object} prop - Theo property
+ * @returns {string}
  */
 function mdxColor(prop) {
   return `
@@ -21,7 +21,7 @@ function mdxColor(prop) {
  * Return a string containing Storybook Docs MDX markup for multiple colors.
  *
  * @param {Array} props - Theo properties
- * @returns {String}
+ * @returns {string}
  */
 function mdxColors(props) {
   const colors = props.map(mdxColor);
@@ -35,8 +35,8 @@ function mdxColors(props) {
  * Return a string containing Storybook Docs MDX markup for a single row of a
  * property table.
  *
- * @param {Object} prop - Theo property
- * @returns {String}
+ * @param {object} prop - Theo property
+ * @returns {string}
  */
 function mdxProp(prop) {
   return `
@@ -51,7 +51,7 @@ function mdxProp(prop) {
  * Return a string containing Storybook Docs MDX markup for a property table.
  *
  * @param {Array} props - Theo properties
- * @returns {String}
+ * @returns {string}
  */
 function mdxProps(props) {
   const rows = props.map(mdxProp);
@@ -69,9 +69,9 @@ function mdxProps(props) {
  * Return a string containing Storybook Docs MDX markup for a single category
  * of Theo properties.
  *
- * @param {String} category - Category of Theo properties
+ * @param {string} category - Category of Theo properties
  * @param {Array} props - Theo properties
- * @returns {String}
+ * @returns {string}
  */
 function categoryToMdx(category, props) {
   const categoryTitle = startCase(category);
@@ -93,7 +93,7 @@ ${categoryBody}
  * Theo format for Storybook Docs (`.stories.mdx`).
  *
  * @param {ImmutableMap} result - Map of Theo properties and meta.
- * @returns {String}
+ * @returns {string}
  */
 function mdxStoriesFormat(result) {
   const file = result.getIn(['meta', 'file']);

--- a/fixtures/downshift/src/hooks/useSelect/utils.js
+++ b/fixtures/downshift/src/hooks/useSelect/utils.js
@@ -86,8 +86,8 @@ const propTypes = {
  * Will specift if there are results in the list, and if so, how many,
  * and what keys are relevant.
  *
- * @param {Object} param the downshift state and other relevant properties
- * @return {String} the a11y status message
+ * @param {object} param the downshift state and other relevant properties
+ * @returns {string} the a11y status message
  */
 function getA11yStatusMessage({ isOpen, resultCount }) {
   if (!isOpen) {

--- a/fixtures/downshift/src/hooks/utils.js
+++ b/fixtures/downshift/src/hooks/utils.js
@@ -112,9 +112,9 @@ function useEnhancedReducer(reducer, initialState, props) {
 /**
  * Default state reducer that returns the changes.
  *
- * @param {Object} s state.
- * @param {Object} a action with changes.
- * @returns {Object} changes.
+ * @param {object} s state.
+ * @param {object} a action with changes.
+ * @returns {object} changes.
  */
 function stateReducer(s, a) {
   return a.changes;
@@ -123,7 +123,7 @@ function stateReducer(s, a) {
 /**
  * Returns a message to be added to aria-live region when item is selected.
  *
- * @param {Object} selectionParameters Parameters required to build the message.
+ * @param {object} selectionParameters Parameters required to build the message.
  * @returns {string} The a11y message.
  */
 function getA11ySelectionMessage(selectionParameters) {

--- a/fixtures/eslint/lib/cli-engine/cascading-config-array-factory.js
+++ b/fixtures/eslint/lib/cli-engine/cascading-config-array-factory.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview `CascadingConfigArrayFactory` class.
+ * @file `CascadingConfigArrayFactory` class.
  *
  * `CascadingConfigArrayFactory` class has a responsibility:
  *
@@ -47,7 +47,7 @@ const debug = require('debug')('eslint:cascading-config-array-factory');
 /** @typedef {ReturnType<ConfigArrayFactory["create"]>} ConfigArray */
 
 /**
- * @typedef {Object} CascadingConfigArrayFactoryOptions
+ * @typedef {object} CascadingConfigArrayFactoryOptions
  * @property {Map<string,Plugin>} [additionalPluginPool] The map for additional plugins.
  * @property {ConfigData} [baseConfig] The config by `baseConfig` option.
  * @property {ConfigData} [cliConfig] The config by CLI options (`--env`, `--global`, `--ignore-pattern`, `--parser`, `--parser-options`, `--plugin`, and `--rule`). CLI options overwrite the setting in config files.
@@ -59,7 +59,7 @@ const debug = require('debug')('eslint:cascading-config-array-factory');
  */
 
 /**
- * @typedef {Object} CascadingConfigArrayFactoryInternalSlots
+ * @typedef {object} CascadingConfigArrayFactoryInternalSlots
  * @property {ConfigArray} baseConfigArray The config array of `baseConfig` option.
  * @property {ConfigData} baseConfigData The config data of `baseConfig` option. This is used to reset `baseConfigArray`.
  * @property {ConfigArray} cliConfigArray The config array of CLI options.
@@ -251,7 +251,7 @@ class CascadingConfigArrayFactory {
    * If `filePath` was not given, it returns the config which contains only
    * `baseConfigData` and `cliConfigData`.
    * @param {string} [filePath] The file path to a file.
-   * @param {Object} [options] The options.
+   * @param {object} [options] The options.
    * @param {boolean} [options.ignoreNotFoundError] If `true` then it doesn't throw `ConfigurationNotFoundError`.
    * @returns {ConfigArray} The config array of the file.
    */

--- a/fixtures/eslint/lib/cli-engine/config-array-factory.js
+++ b/fixtures/eslint/lib/cli-engine/config-array-factory.js
@@ -578,7 +578,7 @@ class ConfigArrayFactory {
    * Normalize a given `.eslintignore` data to config array elements.
    * @param {string[]} ignorePatterns The patterns to ignore files.
    * @param {ConfigArrayFactoryLoadingContext} ctx The loading context.
-   * @yields {ConfigArrayElement}
+   * @yields {ConfigArrayElement} The normalized config.
    * @private
    */
   *_normalizeESLintIgnoreData(ignorePatterns, ctx) {
@@ -610,7 +610,7 @@ class ConfigArrayFactory {
    * Normalize a given config to an array.
    * @param {ConfigData|OverrideConfigData} configData The config data to normalize.
    * @param {ConfigArrayFactoryLoadingContext} ctx The loading context.
-   * @yields {ConfigArrayElement}
+   * @yields {ConfigArrayElement} The normalized config.
    * @private
    */
   *_normalizeObjectConfigData(configData, ctx) {
@@ -647,7 +647,7 @@ class ConfigArrayFactory {
    * Normalize a given config to an array.
    * @param {ConfigData} configData The config data to normalize.
    * @param {ConfigArrayFactoryLoadingContext} ctx The loading context.
-   * @yields {ConfigArrayElement}
+   * @yields {ConfigArrayElement} The normalized config.
    * @private
    */
   *_normalizeObjectConfigDataBody(
@@ -1026,7 +1026,7 @@ class ConfigArrayFactory {
    * Take file expression processors as config array elements.
    * @param {Record<string,DependentPlugin>} plugins The plugin definitions.
    * @param {ConfigArrayFactoryLoadingContext} ctx The loading context.
-   * @yields {ConfigArrayElement}
+   * @yields {ConfigArrayElement} The config array elements of file expression processors.
    * @private
    */
   *_takeFileExtensionProcessors(plugins, ctx) {

--- a/fixtures/eslint/lib/cli-engine/config-array-factory.js
+++ b/fixtures/eslint/lib/cli-engine/config-array-factory.js
@@ -578,7 +578,6 @@ class ConfigArrayFactory {
    * Normalize a given `.eslintignore` data to config array elements.
    * @param {string[]} ignorePatterns The patterns to ignore files.
    * @param {ConfigArrayFactoryLoadingContext} ctx The loading context.
-   * @returns {IterableIterator<ConfigArrayElement>} The normalized config.
    * @private
    */
   *_normalizeESLintIgnoreData(ignorePatterns, ctx) {
@@ -610,7 +609,6 @@ class ConfigArrayFactory {
    * Normalize a given config to an array.
    * @param {ConfigData|OverrideConfigData} configData The config data to normalize.
    * @param {ConfigArrayFactoryLoadingContext} ctx The loading context.
-   * @returns {IterableIterator<ConfigArrayElement>} The normalized config.
    * @private
    */
   *_normalizeObjectConfigData(configData, ctx) {
@@ -647,7 +645,6 @@ class ConfigArrayFactory {
    * Normalize a given config to an array.
    * @param {ConfigData} configData The config data to normalize.
    * @param {ConfigArrayFactoryLoadingContext} ctx The loading context.
-   * @returns {IterableIterator<ConfigArrayElement>} The normalized config.
    * @private
    */
   *_normalizeObjectConfigDataBody(
@@ -1026,7 +1023,6 @@ class ConfigArrayFactory {
    * Take file expression processors as config array elements.
    * @param {Record<string,DependentPlugin>} plugins The plugin definitions.
    * @param {ConfigArrayFactoryLoadingContext} ctx The loading context.
-   * @returns {IterableIterator<ConfigArrayElement>} The config array elements of file expression processors.
    * @private
    */
   *_takeFileExtensionProcessors(plugins, ctx) {

--- a/fixtures/eslint/lib/cli-engine/config-array-factory.js
+++ b/fixtures/eslint/lib/cli-engine/config-array-factory.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview The factory of `ConfigArray` objects.
+ * @file The factory of `ConfigArray` objects.
  *
  * This class provides methods to create `ConfigArray` instance.
  *
@@ -83,21 +83,21 @@ const configFilenames = [
 /** @typedef {ConfigArray[0]} ConfigArrayElement */
 
 /**
- * @typedef {Object} ConfigArrayFactoryOptions
+ * @typedef {object} ConfigArrayFactoryOptions
  * @property {Map<string,Plugin>} [additionalPluginPool] The map for additional plugins.
  * @property {string} [cwd] The path to the current working directory.
  * @property {string} [resolvePluginsRelativeTo] A path to the directory that plugins should be resolved from. Defaults to `cwd`.
  */
 
 /**
- * @typedef {Object} ConfigArrayFactoryInternalSlots
+ * @typedef {object} ConfigArrayFactoryInternalSlots
  * @property {Map<string,Plugin>} additionalPluginPool The map for additional plugins.
  * @property {string} cwd The path to the current working directory.
  * @property {string} resolvePluginsRelativeTo An absolute path the the directory that plugins should be resolved from.
  */
 
 /**
- * @typedef {Object} ConfigArrayFactoryLoadingContext
+ * @typedef {object} ConfigArrayFactoryLoadingContext
  * @property {string} filePath The path to the current configuration.
  * @property {string} matchBasePath The base path to resolve relative paths in `overrides[].files`, `overrides[].excludedFiles`, and `ignorePatterns`.
  * @property {string} name The name of the current configuration.
@@ -407,7 +407,7 @@ class ConfigArrayFactory {
   /**
    * Create `ConfigArray` instance from a config data.
    * @param {ConfigData|null} configData The config data to create.
-   * @param {Object} [options] The options.
+   * @param {object} [options] The options.
    * @param {string} [options.basePath] The base path to resolve relative paths in `overrides[].files`, `overrides[].excludedFiles`, and `ignorePatterns`.
    * @param {string} [options.filePath] The path to this config data.
    * @param {string} [options.name] The config name.
@@ -428,7 +428,7 @@ class ConfigArrayFactory {
   /**
    * Load a config file.
    * @param {string} filePath The path to a config file.
-   * @param {Object} [options] The options.
+   * @param {object} [options] The options.
    * @param {string} [options.basePath] The base path to resolve relative paths in `overrides[].files`, `overrides[].excludedFiles`, and `ignorePatterns`.
    * @param {string} [options.name] The config name.
    * @returns {ConfigArray} Loaded config.
@@ -443,7 +443,7 @@ class ConfigArrayFactory {
   /**
    * Load the config file on a given directory if exists.
    * @param {string} directoryPath The path to a directory.
-   * @param {Object} [options] The options.
+   * @param {object} [options] The options.
    * @param {string} [options.basePath] The base path to resolve relative paths in `overrides[].files`, `overrides[].excludedFiles`, and `ignorePatterns`.
    * @param {string} [options.name] The config name.
    * @returns {ConfigArray} Loaded config. An empty `ConfigArray` if any config doesn't exist.

--- a/fixtures/eslint/lib/cli-engine/config-array-factory.js
+++ b/fixtures/eslint/lib/cli-engine/config-array-factory.js
@@ -578,6 +578,7 @@ class ConfigArrayFactory {
    * Normalize a given `.eslintignore` data to config array elements.
    * @param {string[]} ignorePatterns The patterns to ignore files.
    * @param {ConfigArrayFactoryLoadingContext} ctx The loading context.
+   * @yields {ConfigArrayElement}
    * @private
    */
   *_normalizeESLintIgnoreData(ignorePatterns, ctx) {
@@ -609,6 +610,7 @@ class ConfigArrayFactory {
    * Normalize a given config to an array.
    * @param {ConfigData|OverrideConfigData} configData The config data to normalize.
    * @param {ConfigArrayFactoryLoadingContext} ctx The loading context.
+   * @yields {ConfigArrayElement}
    * @private
    */
   *_normalizeObjectConfigData(configData, ctx) {
@@ -645,6 +647,7 @@ class ConfigArrayFactory {
    * Normalize a given config to an array.
    * @param {ConfigData} configData The config data to normalize.
    * @param {ConfigArrayFactoryLoadingContext} ctx The loading context.
+   * @yields {ConfigArrayElement}
    * @private
    */
   *_normalizeObjectConfigDataBody(
@@ -1023,6 +1026,7 @@ class ConfigArrayFactory {
    * Take file expression processors as config array elements.
    * @param {Record<string,DependentPlugin>} plugins The plugin definitions.
    * @param {ConfigArrayFactoryLoadingContext} ctx The loading context.
+   * @yields {ConfigArrayElement}
    * @private
    */
   *_takeFileExtensionProcessors(plugins, ctx) {

--- a/fixtures/eslint/lib/cli-engine/config-array/ignore-pattern.js
+++ b/fixtures/eslint/lib/cli-engine/config-array/ignore-pattern.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview `IgnorePattern` class.
+ * @file `IgnorePattern` class.
  *
  * `IgnorePattern` class has the set of glob patterns and the base path.
  *

--- a/fixtures/eslint/lib/cli-engine/file-enumerator.js
+++ b/fixtures/eslint/lib/cli-engine/file-enumerator.js
@@ -414,6 +414,7 @@ class FileEnumerator {
    * @param {boolean} [options.dotfiles] If `true` then it doesn't skip dot files by default.
    * @param {boolean} [options.recursive] If `true` then it dives into sub directories.
    * @param {InstanceType<Minimatch>} [options.selector] The matcher to choose files.
+   * @yields {IterableIterator<FileEntry>} The found files.
    * @private
    */
   *_iterateFilesRecursive(directoryPath, options) {

--- a/fixtures/eslint/lib/cli-engine/file-enumerator.js
+++ b/fixtures/eslint/lib/cli-engine/file-enumerator.js
@@ -256,7 +256,6 @@ class FileEnumerator {
   /**
    * Iterate files which are matched by given glob patterns.
    * @param {string|string[]} patternOrPatterns The glob patterns to iterate files.
-   * @returns {IterableIterator<FileAndConfig>} The found files.
    */
   *iterateFiles(patternOrPatterns) {
     const { globInputPaths, errorOnUnmatchedPattern } = internalSlotsMap.get(
@@ -414,7 +413,6 @@ class FileEnumerator {
    * @param {boolean} [options.dotfiles] If `true` then it doesn't skip dot files by default.
    * @param {boolean} [options.recursive] If `true` then it dives into sub directories.
    * @param {InstanceType<Minimatch>} [options.selector] The matcher to choose files.
-   * @returns {IterableIterator<FileEntry>} The found files.
    * @private
    */
   *_iterateFilesRecursive(directoryPath, options) {

--- a/fixtures/eslint/lib/cli-engine/file-enumerator.js
+++ b/fixtures/eslint/lib/cli-engine/file-enumerator.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview `FileEnumerator` class.
+ * @file `FileEnumerator` class.
  *
  * `FileEnumerator` class has two responsibilities:
  *
@@ -60,7 +60,7 @@ const IGNORED = 2;
 /** @typedef {ReturnType<CascadingConfigArrayFactory["getConfigArrayForFile"]>} ConfigArray */
 
 /**
- * @typedef {Object} FileEnumeratorOptions
+ * @typedef {object} FileEnumeratorOptions
  * @property {CascadingConfigArrayFactory} [configArrayFactory] The factory for config arrays.
  * @property {string} [cwd] The base directory to start lookup.
  * @property {string[]} [extensions] The extensions to match files for directory patterns.
@@ -70,14 +70,14 @@ const IGNORED = 2;
  */
 
 /**
- * @typedef {Object} FileAndConfig
+ * @typedef {object} FileAndConfig
  * @property {string} filePath The path to a target file.
  * @property {ConfigArray} config The config entries of that file.
  * @property {boolean} ignored If `true` then this file should be ignored and warned because it was directly specified.
  */
 
 /**
- * @typedef {Object} FileEntry
+ * @typedef {object} FileEntry
  * @property {string} filePath The path to a target file.
  * @property {ConfigArray} config The config entries of that file.
  * @property {NONE|IGNORED_SILENTLY|IGNORED} flag The flag.
@@ -87,7 +87,7 @@ const IGNORED = 2;
  */
 
 /**
- * @typedef {Object} FileEnumeratorInternalSlots
+ * @typedef {object} FileEnumeratorInternalSlots
  * @property {CascadingConfigArrayFactory} configArrayFactory The factory for config arrays.
  * @property {string} cwd The base directory to start lookup.
  * @property {RegExp|null} extensionRegExp The RegExp to test if a string ends with specific file extensions.
@@ -410,7 +410,7 @@ class FileEnumerator {
   /**
    * Iterate files in a given path.
    * @param {string} directoryPath The path to the target directory.
-   * @param {Object} options The options to iterate files.
+   * @param {object} options The options to iterate files.
    * @param {boolean} [options.dotfiles] If `true` then it doesn't skip dot files by default.
    * @param {boolean} [options.recursive] If `true` then it dives into sub directories.
    * @param {InstanceType<Minimatch>} [options.selector] The matcher to choose files.
@@ -488,7 +488,7 @@ class FileEnumerator {
   /**
    * Check if a given file should be ignored.
    * @param {string} filePath The path to a file to check.
-   * @param {Object} options Options
+   * @param {object} options Options
    * @param {ConfigArray} [options.config] The config for this file.
    * @param {boolean} [options.dotfiles] If `true` then this is not ignore dot files by default.
    * @param {boolean} [options.direct] If `true` then this is a direct specified file.

--- a/fixtures/eslint/lib/cli-engine/file-enumerator.js
+++ b/fixtures/eslint/lib/cli-engine/file-enumerator.js
@@ -256,6 +256,7 @@ class FileEnumerator {
   /**
    * Iterate files which are matched by given glob patterns.
    * @param {string|string[]} patternOrPatterns The glob patterns to iterate files.
+   * @yields {FileAndConfig} The found files.
    */
   *iterateFiles(patternOrPatterns) {
     const { globInputPaths, errorOnUnmatchedPattern } = internalSlotsMap.get(

--- a/fixtures/eslint/lib/init/config-initializer.js
+++ b/fixtures/eslint/lib/init/config-initializer.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Config initialization wizard.
+ * @file Config initialization wizard.
  * @author Ilya Volodin
  */
 
@@ -35,7 +35,7 @@ const DEFAULT_ECMA_VERSION = 2018;
 /* istanbul ignore next: hard to test fs function */
 /**
  * Create .eslintrc file in the current working directory
- * @param {Object} config object that contains user's answers
+ * @param {object} config object that contains user's answers
  * @param {string} format The file format to write to.
  * @returns {void}
  */
@@ -68,7 +68,7 @@ function writeFile(config, format) {
  * This adds the gotten value to cache at the first time, then reuses it.
  * In a process, this function is called twice, but `npmUtils.fetchPeerDependencies` needs to access network which is relatively slow.
  * @param {string} moduleName The module name to get.
- * @returns {Object} The peer dependencies of the given module.
+ * @returns {object} The peer dependencies of the given module.
  * This object is the object of `peerDependencies` field of `package.json`.
  * Returns null if npm was not found.
  */
@@ -89,7 +89,7 @@ getPeerDependencies.cache = new Map();
 
 /**
  * Return necessary plugins, configs, parsers, etc. based on the config
- * @param   {Object} config  config object
+ * @param   {object} config  config object
  * @param   {boolean} [installESLint=true]  If `false` is given, it does not install eslint.
  * @returns {string[]} An array of modules to be installed.
  */
@@ -150,9 +150,9 @@ function getModulesList(config, installESLint) {
  *
  * Note: This clones the config object and returns a new config to avoid mutating
  * the original config parameter.
- * @param   {Object} answers  answers received from inquirer
- * @param   {Object} config   config object
- * @returns {Object}          config object with configured rules
+ * @param   {object} answers  answers received from inquirer
+ * @param   {object} config   config object
+ * @returns {object}          config object with configured rules
  */
 function configureRules(answers, config) {
   const BAR_TOTAL = 20;
@@ -275,8 +275,8 @@ function configureRules(answers, config) {
 
 /**
  * Process user's answers and create config object
- * @param {Object} answers answers received from inquirer
- * @returns {Object} config object
+ * @param {object} answers answers received from inquirer
+ * @returns {object} config object
  */
 function processAnswers(answers) {
   let config = {
@@ -383,7 +383,7 @@ function getLocalESLintVersion() {
 
 /**
  * Get the shareable config name of the chosen style guide.
- * @param {Object} answers The answers object.
+ * @param {object} answers The answers object.
  * @returns {string} The shareable config name.
  */
 function getStyleGuideName(answers) {
@@ -396,7 +396,7 @@ function getStyleGuideName(answers) {
 
 /**
  * Check whether the local ESLint version conflicts with the required version of the chosen shareable config.
- * @param {Object} answers The answers object.
+ * @param {object} answers The answers object.
  * @returns {boolean} `true` if the local ESLint is found then it conflicts with the required version of the chosen shareable config.
  */
 function hasESLintVersionConflict(answers) {

--- a/fixtures/eslint/lib/linter/apply-disable-directives.js
+++ b/fixtures/eslint/lib/linter/apply-disable-directives.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview A module that filters reported problems based on `eslint-disable` and `eslint-enable` comments
+ * @file A module that filters reported problems based on `eslint-disable` and `eslint-enable` comments
  * @author Teddy Katz
  */
 
@@ -22,7 +22,7 @@ function compareLocations(itemA, itemB) {
  * This is the same as the exported function, except that it
  * doesn't handle disable-line and disable-next-line directives, and it always reports unused
  * disable directives.
- * @param {Object} options options for applying directives. This is the same as the options
+ * @param {object} options options for applying directives. This is the same as the options
  * for the exported function, except that `reportUnusedDisableDirectives` is not supported
  * (this function always reports unused disable directives).
  * @returns {{problems: Problem[], unusedDisableDirectives: Problem[]}} An object with a list
@@ -111,7 +111,7 @@ function applyDirectives(options) {
 /**
  * Given a list of directive comments (i.e. metadata about eslint-disable and eslint-enable comments) and a list
  * of reported problems, determines which problems should be reported.
- * @param {Object} options Information about directives and problems
+ * @param {object} options Information about directives and problems
  * @param {{
  *      type: ("disable"|"enable"|"disable-line"|"disable-next-line"),
  *      ruleId: (string|null),

--- a/fixtures/eslint/lib/linter/linter.js
+++ b/fixtures/eslint/lib/linter/linter.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Main Linter Class
+ * @file Main Linter Class
  * @author Gyandeep Singh
  * @author aladdin-add
  */
@@ -62,7 +62,7 @@ const DEFAULT_ERROR_LOC = {
  */
 
 /**
- * @typedef {Object} DisableDirective
+ * @typedef {object} DisableDirective
  * @property {("disable"|"enable"|"disable-line"|"disable-next-line")} type
  * @property {number} line
  * @property {number} column
@@ -71,7 +71,7 @@ const DEFAULT_ERROR_LOC = {
 
 /**
  * The private data for `Linter` instance.
- * @typedef {Object} LinterInternalSlots
+ * @typedef {object} LinterInternalSlots
  * @property {ConfigArray|null} lastConfigArray The `ConfigArray` instance that the last `verify()` call used.
  * @property {SourceCode|null} lastSourceCode The `SourceCode` instance that the last `verify()` call used.
  * @property {Map<string, Parser>} parserMap The loaded parsers.
@@ -79,7 +79,7 @@ const DEFAULT_ERROR_LOC = {
  */
 
 /**
- * @typedef {Object} VerifyOptions
+ * @typedef {object} VerifyOptions
  * @property {boolean} [allowInlineConfig] Allow/disallow inline comments' ability
  *      to change config once it is set. Defaults to true if not supplied.
  *      Useful if you want to validate JS without comments overriding rules.
@@ -91,7 +91,7 @@ const DEFAULT_ERROR_LOC = {
  */
 
 /**
- * @typedef {Object} ProcessorOptions
+ * @typedef {object} ProcessorOptions
  * @property {(filename:string, text:string) => boolean} [filterCodeBlock] the
  *      predicate function that selects adopt code blocks.
  * @property {Processor["postprocess"]} [postprocess] postprocessor for report
@@ -105,13 +105,13 @@ const DEFAULT_ERROR_LOC = {
  */
 
 /**
- * @typedef {Object} FixOptions
+ * @typedef {object} FixOptions
  * @property {boolean | ((message: LintMessage) => boolean)} [fix] Determines
  *      whether fixes should be applied.
  */
 
 /**
- * @typedef {Object} InternalOptions
+ * @typedef {object} InternalOptions
  * @property {string | null} warnInlineConfig The config name what `noInlineConfig` setting came from. If `noInlineConfig` setting didn't exist, this is null. If this is a config name, then the linter warns directive comments.
  * @property {"off" | "warn" | "error"} reportUnusedDisableDirectives (boolean values were normalized)
  */
@@ -125,8 +125,8 @@ const DEFAULT_ERROR_LOC = {
  * and any globals declared by special block comments, are present in the global
  * scope.
  * @param {Scope} globalScope The global scope.
- * @param {Object} configGlobals The globals declared in configuration
- * @param {{exportedVariables: Object, enabledGlobals: Object}} commentDirectives Directives from comment configuration
+ * @param {object} configGlobals The globals declared in configuration
+ * @param {{exportedVariables: object, enabledGlobals: object}} commentDirectives Directives from comment configuration
  * @returns {void}
  */
 function addDeclaredGlobals(
@@ -219,9 +219,9 @@ function createMissingRuleMessage(ruleId) {
 
 /**
  * Creates a linting problem
- * @param {Object} options to create linting error
+ * @param {object} options to create linting error
  * @param {string} [options.ruleId] the ruleId to report
- * @param {Object} [options.loc] the loc to report
+ * @param {object} [options.loc] the loc to report
  * @param {string} [options.message] the error message to report
  * @param {string} [options.severity] the error message to report
  * @returns {LintMessage} created problem, returns a missing-rule problem if only provided ruleId.
@@ -249,13 +249,13 @@ function createLintingProblem(options) {
 
 /**
  * Creates a collection of disable directives from a comment
- * @param {Object} options to create disable directives
+ * @param {object} options to create disable directives
  * @param {("disable"|"enable"|"disable-line"|"disable-next-line")} options.type The type of directive comment
  * @param {{line: number, column: number}} options.loc The 0-based location of the comment token
  * @param {string} options.value The value after the directive in the comment
  * comment specified no specific rules, so it applies to all rules (e.g. `eslint-disable`)
- * @param {function(string): {create: Function}} options.ruleMapper A map from rule IDs to defined rules
- * @returns {Object} Directives and problems from the comment
+ * @param {function(string): {create: () => void}} options.ruleMapper A map from rule IDs to defined rules
+ * @returns {object} Directives and problems from the comment
  */
 function createDisableDirectives(options) {
   const { type, loc, value, ruleMapper } = options;
@@ -298,7 +298,7 @@ function stripDirectiveComment(value) {
  * where reporting is disabled or enabled and merges them with reporting config.
  * @param {string} filename The file being checked.
  * @param {ASTNode} ast The top node of the AST.
- * @param {function(string): {create: Function}} ruleMapper A map from rule IDs to defined rules
+ * @param {function(string): {create: () => void}} ruleMapper A map from rule IDs to defined rules
  * @param {string|null} warnInlineConfig If a string then it should warn directive comments as disabled. The string value is the config name what the setting came from.
  * @returns {{configuredRules: Object, enabledGlobals: {value:string,comment:Token}[], exportedVariables: Object, problems: Problem[], disableDirectives: DisableDirective[]}}
  * A collection of the directive comments that were found, along with any problems that occurred when parsing
@@ -502,7 +502,7 @@ const eslintEnvPattern = /\/\*\s*eslint-env\s(.+?)\*\//gu;
 /**
  * Checks whether or not there is a comment which has "eslint-env *" in a given text.
  * @param {string} text A source code text to check.
- * @returns {Object|null} A result of parseListConfig() with "eslint-env *" comment.
+ * @returns {object|null} A result of parseListConfig() with "eslint-env *" comment.
  */
 function findEslintEnv(text) {
   let match, retv;
@@ -809,7 +809,7 @@ function getScope(scopeManager, currentNode) {
  * Marks a variable as used in the current scope
  * @param {ScopeManager} scopeManager The scope manager for this AST. The scope may be mutated by this function.
  * @param {ASTNode} currentNode The node currently being traversed
- * @param {Object} parserOptions The options used to parse this text
+ * @param {object} parserOptions The options used to parse this text
  * @param {string} name The name of the variable that should be marked as used.
  * @returns {boolean} True if the variable was found and marked as used, false if not.
  */
@@ -841,7 +841,7 @@ function markVariableAsUsed(scopeManager, currentNode, parserOptions, name) {
  * Runs a rule, and gets its listeners
  * @param {Rule} rule A normalized rule with a `create` method
  * @param {Context} ruleContext The context that should be passed to the rule
- * @returns {Object} A map of selector listeners provided by the rule
+ * @returns {object} A map of selector listeners provided by the rule
  */
 function createRuleListeners(rule, ruleContext) {
   try {
@@ -909,11 +909,11 @@ const BASE_TRAVERSAL_CONTEXT = Object.freeze(
 /**
  * Runs the given rules on the given SourceCode object
  * @param {SourceCode} sourceCode A SourceCode object for the given text
- * @param {Object} configuredRules The rules configuration
+ * @param {object} configuredRules The rules configuration
  * @param {function(string): Rule} ruleMapper A mapper function from rule names to rules
- * @param {Object} parserOptions The options that were passed to the parser
+ * @param {object} parserOptions The options that were passed to the parser
  * @param {string} parserName The name of the parser in the config
- * @param {Object} settings The settings that were enabled in the config
+ * @param {object} settings The settings that were enabled in the config
  * @param {string} filename The reported filename of the code
  * @param {boolean} disableFixes If true, it doesn't make `fix` properties.
  * @param {string | undefined} cwd cwd of the cli
@@ -1145,7 +1145,7 @@ const internalSlotsMap = new WeakMap();
 class Linter {
   /**
    * Initialize the Linter.
-   * @param {Object} [config] the config object
+   * @param {object} [config] the config object
    * @param {string} [config.cwd]  path to a directory that should be considered as the current working directory, can be undefined.
    */
   constructor({ cwd } = {}) {
@@ -1462,7 +1462,7 @@ class Linter {
   /**
    * Defines a new linting rule.
    * @param {string} ruleId A unique rule identifier
-   * @param {Function | Rule} ruleModule Function from context to object mapping AST node types to event handlers
+   * @param {() => void|Rule} ruleModule Function from context to object mapping AST node types to event handlers
    * @returns {void}
    */
   defineRule(ruleId, ruleModule) {
@@ -1471,7 +1471,7 @@ class Linter {
 
   /**
    * Defines many new linting rules.
-   * @param {Record<string, Function | Rule>} rulesToDefine map from unique rule identifier to rule
+   * @param {Record<string, () => void|Rule>} rulesToDefine map from unique rule identifier to rule
    * @returns {void}
    */
   defineRules(rulesToDefine) {

--- a/fixtures/eslint/lib/linter/node-event-generator.js
+++ b/fixtures/eslint/lib/linter/node-event-generator.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview The event generator for AST nodes.
+ * @file The event generator for AST nodes.
  * @author Toru Nagashima
  */
 
@@ -18,10 +18,10 @@ const lodash = require('lodash');
 
 /**
  * An object describing an AST selector
- * @typedef {Object} ASTSelector
+ * @typedef {object} ASTSelector
  * @property {string} rawSelector The string that was parsed into this selector
  * @property {boolean} isExit `true` if this should be emitted when exiting the node rather than when entering
- * @property {Object} parsedSelector An object (from esquery) describing the matching behavior of the selector
+ * @property {object} parsedSelector An object (from esquery) describing the matching behavior of the selector
  * @property {string[]|null} listenerTypes A list of node types that could possibly cause the selector to match,
  * or `null` if all node types could cause a match
  * @property {number} attributeCount The total number of classes, pseudo-classes, and attribute queries in this selector
@@ -34,7 +34,7 @@ const lodash = require('lodash');
 
 /**
  * Gets the possible types of a selector
- * @param {Object} parsedSelector An object (from esquery) describing the matching behavior of the selector
+ * @param {object} parsedSelector An object (from esquery) describing the matching behavior of the selector
  * @returns {string[]|null} The node types that could possibly trigger this selector, or `null` if all node types could trigger it
  */
 function getPossibleTypes(parsedSelector) {
@@ -82,7 +82,7 @@ function getPossibleTypes(parsedSelector) {
 
 /**
  * Counts the number of class, pseudo-class, and attribute queries in this selector
- * @param {Object} parsedSelector An object (from esquery) describing the selector's matching behavior
+ * @param {object} parsedSelector An object (from esquery) describing the selector's matching behavior
  * @returns {number} The number of class, pseudo-class, and attribute queries in this selector
  */
 function countClassAttributes(parsedSelector) {
@@ -117,7 +117,7 @@ function countClassAttributes(parsedSelector) {
 
 /**
  * Counts the number of identifier queries in this selector
- * @param {Object} parsedSelector An object (from esquery) describing the selector's matching behavior
+ * @param {object} parsedSelector An object (from esquery) describing the selector's matching behavior
  * @returns {number} The number of identifier queries
  */
 function countIdentifiers(parsedSelector) {
@@ -168,7 +168,7 @@ function compareSpecificity(selectorA, selectorB) {
 /**
  * Parses a raw selector string, and throws a useful error if parsing fails.
  * @param {string} rawSelector A raw AST selector
- * @returns {Object} An object (from esquery) describing the matching behavior of this selector
+ * @returns {object} An object (from esquery) describing the matching behavior of this selector
  * @throws {Error} An error if the selector is invalid
  */
 function tryParseSelector(rawSelector) {

--- a/fixtures/eslint/lib/rules/keyword-spacing.js
+++ b/fixtures/eslint/lib/rules/keyword-spacing.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Rule to enforce spacing before and after keywords.
+ * @file Rule to enforce spacing before and after keywords.
  * @author Toru Nagashima
  */
 
@@ -230,8 +230,8 @@ module.exports = {
 
     /**
      * Parses the option object and determines check methods for each keyword.
-     * @param {Object|undefined} options The option object to parse.
-     * @returns {Object} - Normalized option object.
+     * @param {object|undefined} options The option object to parse.
+     * @returns {object} - Normalized option object.
      *      Keys are keywords (there are for every keyword).
      *      Values are instances of `{"before": function, "after": function}`.
      */

--- a/fixtures/eslint/lib/rules/padding-line-between-statements.js
+++ b/fixtures/eslint/lib/rules/padding-line-between-statements.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Rule to require or disallow newlines between statements
+ * @file Rule to require or disallow newlines between statements
  * @author Toru Nagashima
  */
 
@@ -26,7 +26,7 @@ const CJS_IMPORT = /^require\(/u;
 /**
  * Creates tester which check if a node starts with specific keyword.
  * @param {string} keyword The keyword to test.
- * @returns {Object} the created tester.
+ * @returns {object} the created tester.
  * @private
  */
 function newKeywordTester(keyword) {
@@ -39,7 +39,7 @@ function newKeywordTester(keyword) {
 /**
  * Creates tester which check if a node starts with specific keyword and spans a single line.
  * @param {string} keyword The keyword to test.
- * @returns {Object} the created tester.
+ * @returns {object} the created tester.
  * @private
  */
 function newSinglelineKeywordTester(keyword) {
@@ -53,7 +53,7 @@ function newSinglelineKeywordTester(keyword) {
 /**
  * Creates tester which check if a node starts with specific keyword and spans multiple lines.
  * @param {string} keyword The keyword to test.
- * @returns {Object} the created tester.
+ * @returns {object} the created tester.
  * @private
  */
 function newMultilineKeywordTester(keyword) {
@@ -67,7 +67,7 @@ function newMultilineKeywordTester(keyword) {
 /**
  * Creates tester which check if a node is specific type.
  * @param {string} type The node type to test.
- * @returns {Object} the created tester.
+ * @returns {object} the created tester.
  * @private
  */
 function newNodeTypeTester(type) {
@@ -527,7 +527,7 @@ module.exports = {
      * Finds the last matched configure from configureList.
      * @param {ASTNode} prevNode The previous statement to match.
      * @param {ASTNode} nextNode The current statement to match.
-     * @returns {Object} The tester of the last matched configure.
+     * @returns {object} The tester of the last matched configure.
      * @private
      */
     function getPaddingType(prevNode, nextNode) {

--- a/fixtures/eslint/lib/rules/prefer-arrow-callback.js
+++ b/fixtures/eslint/lib/rules/prefer-arrow-callback.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview A rule to suggest using arrow functions as callbacks.
+ * @file A rule to suggest using arrow functions as callbacks.
  * @author Toru Nagashima
  */
 
@@ -55,7 +55,7 @@ function getVariableOfArguments(scope) {
 /**
  * Checks whether or not a given node is a callback.
  * @param {ASTNode} node A node to check.
- * @returns {Object}
+ * @returns {object}
  *   {boolean} retv.isCallback - `true` if the node is a callback.
  *   {boolean} retv.isLexicalThis - `true` if the node is with `.bind(this)`.
  */

--- a/fixtures/eslint/lib/rules/require-atomic-updates.js
+++ b/fixtures/eslint/lib/rules/require-atomic-updates.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview disallow assignments that can lead to race conditions due to usage of `await` or `yield`
+ * @file disallow assignments that can lead to race conditions due to usage of `await` or `yield`
  * @author Teddy Katz
  * @author Toru Nagashima
  */

--- a/fixtures/eslint/lib/rules/utils/ast-utils.js
+++ b/fixtures/eslint/lib/rules/utils/ast-utils.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Common utils for AST.
+ * @file Common utils for AST.
  * @author Gyandeep Singh
  */
 
@@ -228,8 +228,8 @@ function isMethodWhichHasThisArg(node) {
 
 /**
  * Creates the negate function of the given function.
- * @param {Function} f The function to negate.
- * @returns {Function} Negated function.
+ * @param {() => void} f The function to negate.
+ * @returns {() => void} Negated function.
  */
 function negate(f) {
   return (token) => !f(token);
@@ -448,8 +448,8 @@ module.exports = {
 
   /**
    * Determines whether two adjacent tokens are on the same line.
-   * @param {Object} left The left token object.
-   * @param {Object} right The right token object.
+   * @param {object} left The left token object.
+   * @param {object} right The right token object.
    * @returns {boolean} Whether or not the tokens are on the same line.
    * @public
    */

--- a/fixtures/eslint/lib/source-code/source-code.js
+++ b/fixtures/eslint/lib/source-code/source-code.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Abstraction of JavaScript source code.
+ * @file Abstraction of JavaScript source code.
  * @author Nicholas C. Zakas
  */
 'use strict';
@@ -156,12 +156,12 @@ function isSpaceBetween(sourceCode, first, second, checkInsideOfJSXText) {
 class SourceCode extends TokenStore {
   /**
    * Represents parsed source code.
-   * @param {string|Object} textOrConfig The source code text or config object.
+   * @param {string|object} textOrConfig The source code text or config object.
    * @param {string} textOrConfig.text The source code text.
    * @param {ASTNode} textOrConfig.ast The Program node of the AST representing the code. This AST should be created from the text that BOM was stripped.
-   * @param {Object|null} textOrConfig.parserServices The parser services.
+   * @param {object|null} textOrConfig.parserServices The parser services.
    * @param {ScopeManager|null} textOrConfig.scopeManager The scope of this source code.
-   * @param {Object|null} textOrConfig.visitorKeys The visitor keys to traverse AST.
+   * @param {object|null} textOrConfig.visitorKeys The visitor keys to traverse AST.
    * @param {ASTNode} [astIfNoConfig] The Program node of the AST representing the code. This AST should be created from the text that BOM was stripped.
    */
   constructor(textOrConfig, astIfNoConfig) {
@@ -203,7 +203,7 @@ class SourceCode extends TokenStore {
 
     /**
      * The parser services of this source code.
-     * @type {Object}
+     * @type {object}
      */
     this.parserServices = parserServices || {};
 
@@ -215,7 +215,7 @@ class SourceCode extends TokenStore {
 
     /**
      * The visitor keys to traverse AST.
-     * @type {Object}
+     * @type {object}
      */
     this.visitorKeys = visitorKeys || Traverser.DEFAULT_VISITOR_KEYS;
 
@@ -324,7 +324,7 @@ class SourceCode extends TokenStore {
   /**
    * Gets all comments for the given node.
    * @param {ASTNode} node The AST node to get the comments for.
-   * @returns {Object} An object containing a leading and trailing array
+   * @returns {object} An object containing a leading and trailing array
    *      of comments indexed by their position.
    * @public
    */
@@ -546,7 +546,7 @@ class SourceCode extends TokenStore {
   /**
    * Converts a source text index into a (line, column) pair.
    * @param {number} index The index of a character in a file
-   * @returns {Object} A {line, column} location object with a 0-indexed column
+   * @returns {object} A {line, column} location object with a 0-indexed column
    * @public
    */
   getLocFromIndex(index) {
@@ -588,7 +588,7 @@ class SourceCode extends TokenStore {
 
   /**
    * Converts a (line, column) pair into a range index.
-   * @param {Object} loc A line/column location
+   * @param {object} loc A line/column location
    * @param {number} loc.line The line number of the location (1-indexed)
    * @param {number} loc.column The column number of the location (0-indexed)
    * @returns {number} The range index of the location in the file.

--- a/fixtures/eslint/tools/code-sample-minimizer.js
+++ b/fixtures/eslint/tools/code-sample-minimizer.js
@@ -32,12 +32,12 @@ function isStatement(node) {
  * Given "bad" source text (e.g. an code sample that causes a rule to crash), tries to return a smaller
  * piece of source text which is also "bad", to make it easier for a human to figure out where the
  * problem is.
- * @param {Object} options Options to process
+ * @param {object} options Options to process
  * @param {string} options.sourceText Initial piece of "bad" source text
  * @param {function(string): boolean} options.predicate A predicate that returns `true` for bad source text and `false` for good source text
  * @param {Parser} [options.parser] The parser used to parse the source text. Defaults to a modified
  * version of espree that uses recent parser options.
- * @param {Object} [options.visitorKeys] The visitor keys of the AST. Defaults to eslint-visitor-keys.
+ * @param {object} [options.visitorKeys] The visitor keys of the AST. Defaults to eslint-visitor-keys.
  * @returns {string} Another piece of "bad" source text, which may or may not be smaller than the original source text.
  */
 function reduceBadExampleSize({

--- a/fixtures/mocha/browser-entry.js
+++ b/fixtures/mocha/browser-entry.js
@@ -105,7 +105,7 @@ Mocha.Runner.immediately = function (callback) {
  * This is useful when running tests in a browser because window.onerror will
  * only receive the 'message' attribute of the Error.
  *
- * @param err
+ * @param {Error} err
  */
 mocha.throwError = function (err) {
   uncaughtExceptionHandlers.forEach(function (fn) {

--- a/fixtures/mocha/browser-entry.js
+++ b/fixtures/mocha/browser-entry.js
@@ -14,7 +14,7 @@ const Mocha = require('./lib/mocha');
 /**
  * Create a Mocha instance.
  *
- * @return {undefined}
+ * @returns {undefined}
  */
 
 const mocha = new Mocha({ reporter: 'html' });
@@ -104,6 +104,8 @@ Mocha.Runner.immediately = function (callback) {
  * Function to allow assertion libraries to throw errors directly into mocha.
  * This is useful when running tests in a browser because window.onerror will
  * only receive the 'message' attribute of the Error.
+ *
+ * @param err
  */
 mocha.throwError = function (err) {
   uncaughtExceptionHandlers.forEach(function (fn) {

--- a/fixtures/mocha/lib/cli/one-and-dones.js
+++ b/fixtures/mocha/lib/cli/one-and-dones.js
@@ -14,7 +14,7 @@ const Mocha = require('../mocha');
 /**
  * Dumps a sorted list of the enumerable, lower-case keys of some object
  * to `STDOUT`.
- * @param {Object} obj - Object, ostensibly having some enumerable keys
+ * @param {object} obj - Object, ostensibly having some enumerable keys
  * @ignore
  * @private
  */

--- a/fixtures/mocha/lib/cli/options.js
+++ b/fixtures/mocha/lib/cli/options.js
@@ -87,8 +87,8 @@ const nargOpts = types.array
 /**
  * Wrapper around `yargs-parser` which applies our settings
  * @param {string|string[]} args - Arguments to parse
- * @param {Object} defaultValues - Default values of mocharc.json
- * @param  {...Object} configObjects - `configObjects` for yargs-parser
+ * @param {object} defaultValues - Default values of mocharc.json
+ * @param  {...object} configObjects - `configObjects` for yargs-parser
  * @private
  * @ignore
  */
@@ -143,7 +143,7 @@ const parse = (args = [], defaultValues = {}, ...configObjects) => {
 
 /**
  * Given path to config file in `args.config`, attempt to load & parse config file.
- * @param {Object} [args] - Arguments object
+ * @param {object} [args] - Arguments object
  * @param {string|boolean} [args.config] - Path to config file or `false` to skip
  * @public
  * @memberof module:lib/cli/options
@@ -160,7 +160,7 @@ module.exports.loadRc = loadRc;
 
 /**
  * Given path to `package.json` in `args.package`, attempt to load config from `mocha` prop.
- * @param {Object} [args] - Arguments object
+ * @param {object} [args] - Arguments object
  * @param {string|boolean} [args.config] - Path to `package.json` or `false` to skip
  * @public
  * @memberof module:lib/cli/options

--- a/fixtures/mocha/lib/growl.js
+++ b/fixtures/mocha/lib/growl.js
@@ -22,7 +22,7 @@ const { EVENT_RUN_END } = require('./runner').constants;
  * @see {@link https://github.com/tj/node-growl/blob/master/README.md|Prerequisite Installs}
  * @see {@link Mocha#growl}
  * @see {@link Mocha#isGrowlCapable}
- * @return {boolean} whether Growl notification support can be expected
+ * @returns {boolean} whether Growl notification support can be expected
  */
 exports.isCapable = () => {
   if (!process.browser) {
@@ -94,7 +94,7 @@ const display = (runner) => {
  *
  * @private
  * @callback Growl~growlCB
- * @param {*} err - Error object, or <code>null</code> if successful.
+ * @param {any} err - Error object, or <code>null</code> if successful.
  */
 function onCompletion(err) {
   if (err) {
@@ -109,7 +109,7 @@ function onCompletion(err) {
  * Returns Mocha logo image path.
  *
  * @private
- * @return {string} Pathname of Mocha logo
+ * @returns {string} Pathname of Mocha logo
  */
 const logo = () => {
   return path.join(__dirname, '..', 'assets', 'mocha-logo-96.png');
@@ -125,7 +125,7 @@ const logo = () => {
  *
  * @private
  * @see {@link https://github.com/tj/node-growl/blob/master/lib/growl.js#L28-L126|setupCmd}
- * @return {string[]} names of Growl support binaries
+ * @returns {string[]} names of Growl support binaries
  */
 const getSupportBinaries = () => {
   const binaries = {

--- a/fixtures/mocha/lib/interfaces/common.js
+++ b/fixtures/mocha/lib/interfaces/common.js
@@ -10,7 +10,7 @@ const createMissingArgumentError = errors.createMissingArgumentError;
  * @param {Suite[]} suites
  * @param {Context} context
  * @param {Mocha} mocha
- * @return {Object} An object containing common functions.
+ * @returns {object} An object containing common functions.
  */
 module.exports = function (suites, context, mocha) {
   /**
@@ -35,7 +35,7 @@ module.exports = function (suites, context, mocha) {
      * root suite execution.
      *
      * @param {Suite} suite The root suite.
-     * @return {Function} A function which runs the root suite
+     * @returns {() => void} A function which runs the root suite
      */
     runWithSuite: function runWithSuite(suite) {
       return function run() {
@@ -47,7 +47,7 @@ module.exports = function (suites, context, mocha) {
      * Execute before running tests.
      *
      * @param {string} name
-     * @param {Function} fn
+     * @param {() => void} fn
      */
     before(name, fn) {
       suites[0].beforeAll(name, fn);
@@ -57,7 +57,7 @@ module.exports = function (suites, context, mocha) {
      * Execute after running tests.
      *
      * @param {string} name
-     * @param {Function} fn
+     * @param {() => void} fn
      */
     after(name, fn) {
       suites[0].afterAll(name, fn);
@@ -67,7 +67,7 @@ module.exports = function (suites, context, mocha) {
      * Execute before each test case.
      *
      * @param {string} name
-     * @param {Function} fn
+     * @param {() => void} fn
      */
     beforeEach(name, fn) {
       suites[0].beforeEach(name, fn);
@@ -77,7 +77,7 @@ module.exports = function (suites, context, mocha) {
      * Execute after each test case.
      *
      * @param {string} name
-     * @param {Function} fn
+     * @param {() => void} fn
      */
     afterEach(name, fn) {
       suites[0].afterEach(name, fn);
@@ -88,7 +88,7 @@ module.exports = function (suites, context, mocha) {
        * Create an exclusive Suite; convenience function
        * See docstring for create() below.
        *
-       * @param {Object} opts
+       * @param {object} opts
        * @returns {Suite}
        */
       only: function only(opts) {
@@ -100,7 +100,7 @@ module.exports = function (suites, context, mocha) {
        * Create a Suite, but skip it; convenience function
        * See docstring for create() below.
        *
-       * @param {Object} opts
+       * @param {object} opts
        * @returns {Suite}
        */
       skip: function skip(opts) {
@@ -111,9 +111,9 @@ module.exports = function (suites, context, mocha) {
       /**
        * Creates a suite.
        *
-       * @param {Object} opts Options
+       * @param {object} opts Options
        * @param {string} opts.title Title of Suite
-       * @param {Function} [opts.fn] Suite Function (not always applicable)
+       * @param {() => void} [opts.fn] Suite Function (not always applicable)
        * @param {boolean} [opts.pending] Is Suite pending?
        * @param {string} [opts.file] Filepath where this Suite resides
        * @param {boolean} [opts.isOnly] Is Suite exclusive?
@@ -160,9 +160,9 @@ module.exports = function (suites, context, mocha) {
       /**
        * Exclusive test-case.
        *
-       * @param {Object} mocha
-       * @param {Function} test
-       * @returns {*}
+       * @param {object} mocha
+       * @param {() => void} test
+       * @returns {any}
        */
       only(mocha, test) {
         test.parent.appendOnlyTest(test);

--- a/fixtures/mocha/scripts/markdown-magic.config.js
+++ b/fixtures/mocha/scripts/markdown-magic.config.js
@@ -16,6 +16,9 @@ const stripAnsi = require('strip-ansi');
 exports.transforms = {
   /**
    * Takes STDOUT of some command and injects it into the markdown
+   *
+   * @param content
+   * @param options
    */
   usage: (content, options) => {
     const { executable } = options;
@@ -37,6 +40,10 @@ exports.transforms = {
    * nor can we provide a custom filter.  the custom filter would be required
    * since the `TOC` plugin supplies its own which means we can't use the
    * `maxdepth` option, which we need!
+   *
+   * @param content
+   * @param options
+   * @param config
    */
   toc: (content, options, config) => {
     const IGNORED_HEADINGS_REGEXP = /features|table of contents/i;
@@ -55,6 +62,10 @@ exports.transforms = {
    * Inserts the contents of a file; takes same options as builtin CODE plugin,
    * but does not fetch remote URLs, tries to replace relative paths, and
    * formats in a way our markdown linter likes.
+   *
+   * @param content
+   * @param options
+   * @param config
    */
   file: (content, options, config) => {
     let output;

--- a/fixtures/mocha/scripts/markdown-magic.config.js
+++ b/fixtures/mocha/scripts/markdown-magic.config.js
@@ -17,8 +17,8 @@ exports.transforms = {
   /**
    * Takes STDOUT of some command and injects it into the markdown
    *
-   * @param content
-   * @param options
+   * @param {string} content
+   * @param {object} options
    */
   usage: (content, options) => {
     const { executable } = options;
@@ -41,9 +41,9 @@ exports.transforms = {
    * since the `TOC` plugin supplies its own which means we can't use the
    * `maxdepth` option, which we need!
    *
-   * @param content
-   * @param options
-   * @param config
+   * @param {string} content
+   * @param {object} options
+   * @param {object} config
    */
   toc: (content, options, config) => {
     const IGNORED_HEADINGS_REGEXP = /features|table of contents/i;
@@ -63,9 +63,9 @@ exports.transforms = {
    * but does not fetch remote URLs, tries to replace relative paths, and
    * formats in a way our markdown linter likes.
    *
-   * @param content
-   * @param options
-   * @param config
+   * @param {string} content
+   * @param {object} options
+   * @param {object} config
    */
   file: (content, options, config) => {
     let output;

--- a/package-lock.json
+++ b/package-lock.json
@@ -311,6 +311,7 @@
         "@babel/core": "^7.2.0",
         "babel-eslint": "^10.0.1",
         "eslint-plugin-import": "^2.14.0",
+        "eslint-plugin-jsdoc": "^22.1.0",
         "eslint-plugin-node": "^11.0.0",
         "eslint-plugin-promise": "^4.0.1",
         "eslint-plugin-standard": "^4.0.0",
@@ -1622,6 +1623,11 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "comment-parser": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.7.2.tgz",
+      "integrity": "sha512-4Rjb1FnxtOcv9qsfuaNuVsmmVn4ooVoBHzYfyKteiXwIU84PClyGA5jASoFMwPV93+FPh9spwueXauxFJZkGAg=="
+    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -2211,6 +2217,27 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "eslint-plugin-jsdoc": {
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-22.1.0.tgz",
+      "integrity": "sha512-54NdbICM7KrxsGUqQsev9aIMqPXyvyBx2218Qcm0TQ16P9CtBI+YY4hayJR6adrxlq4Ej0JLpgfUXWaQVFqmQg==",
+      "requires": {
+        "comment-parser": "^0.7.2",
+        "debug": "^4.1.1",
+        "jsdoctypeparser": "^6.1.0",
+        "lodash": "^4.17.15",
+        "regextras": "^0.7.0",
+        "semver": "^6.3.0",
+        "spdx-expression-parse": "^3.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },
@@ -4813,6 +4840,11 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true
     },
+    "jsdoctypeparser": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-6.1.0.tgz",
+      "integrity": "sha512-UCQBZ3xCUBv/PLfwKAJhp6jmGOSLFNKzrotXGNgbKhWvz27wPsCsVeP7gIcHPElQw2agBmynAitXqhxR58XAmA=="
+    },
     "jsdom": {
       "version": "15.2.1",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-15.2.1.tgz",
@@ -5671,6 +5703,11 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
       "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q=="
+    },
+    "regextras": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/regextras/-/regextras-0.7.0.tgz",
+      "integrity": "sha512-ds+fL+Vhl918gbAUb0k2gVKbTZLsg84Re3DI6p85Et0U0tYME3hyW4nMK8Px4dtDaBA2qNjvG5uWyW7eK5gfmw=="
     },
     "remove-trailing-separator": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@babel/core": "^7.2.0",
     "babel-eslint": "^10.0.1",
     "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-jsdoc": "^22.1.0",
     "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",

--- a/src/rules.js
+++ b/src/rules.js
@@ -3,8 +3,17 @@ const eslintImport = require('eslint-plugin-import').rules;
 const standard = require('eslint-plugin-standard').rules;
 const promise = require('eslint-plugin-promise').rules;
 const unicorn = require('eslint-plugin-unicorn').rules;
+const jsdoc = require('eslint-plugin-jsdoc').rules;
 const noParamReassign = require('./rules/no-param-reassign');
 
+/**
+ * Prefixes each rule of the config
+ * Example if `prefix` is `node`:
+ * changes rule callback-return to node/callback-return
+ *
+ * @param {string} prefix
+ * @param {{[key: string]: unknown}} rules
+ */
 const hoist = (prefix, rules) =>
   Object.entries(rules).reduce((output, [key, val]) => {
     output[`${prefix}/${key}`] = val;
@@ -17,6 +26,7 @@ const rules = {
   ...hoist('standard', standard),
   ...hoist('promise', promise),
   ...hoist('unicorn', unicorn),
+  ...hoist('jsdoc', jsdoc),
   'no-param-reassign': noParamReassign,
 };
 

--- a/src/rules/no-param-reassign/index.js
+++ b/src/rules/no-param-reassign/index.js
@@ -1,7 +1,7 @@
 /* eslint-disable @cloudfour/unicorn/consistent-function-scoping */
 
 /**
- * @fileoverview Disallow reassignment of function parameters.
+ * @file Disallow reassignment of function parameters.
  * @author Nat Burns
  */
 'use strict';

--- a/src/rules/no-param-reassign/index.test.js
+++ b/src/rules/no-param-reassign/index.test.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Disallow reassignment of function parameters.
+ * @file Disallow reassignment of function parameters.
  * @author Nat Burns
  */
 'use strict';


### PR DESCRIPTION
Lints JSDoc comments!

Closes #21 

This is _not_ a typechecker. This looks at JSDoc comments and updates formatting and conventions. If you want a typechecker for JSDoc comments, use typescript.

All files in this PR should be reviewed, including fixtures files. Most of the changes in fixtures files were automated (the automated and manual changes are in different commits so you can look at those).

here are some changes that this JSDoc plugin will do:

- `@return` => `@returns`
- `@arg` => `@param`
- `{*}` => `{any}`

https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html#number-string-boolean-symbol-and-object
- `{Object}` => `{object}`
- `{String}` => `{string}`
- `{Number}` => `{number}`

This plugin will also flag any functions that have JSDoc comments but are missing `@param` annotations for some parameters. It does not flag functions that are missing JSDoc comments entirely, because that would be really annoying.