### PR TITLE
Retroactively add changesets for unreleased changes

### DIFF
--- a/.changeset/serious-squids-burn.md
+++ b/.changeset/serious-squids-burn.md
@@ -1,0 +1,7 @@
+---
+'@cloudfour/eslint-plugin': major
+---
+
+Remove rule: @cloudfour/no-param-reassign
+
+This change is breaking if you have `// eslint-disable-next-line @cloudfour-no-param-reassign` in your code, or if you are manually enabling/configuring this rule. In either case, the migration path is to remove the rule configuration

--- a/.changeset/serious-squids-burn.md
+++ b/.changeset/serious-squids-burn.md
@@ -4,4 +4,4 @@
 
 Remove rule: @cloudfour/no-param-reassign
 
-This change is breaking if you have `// eslint-disable-next-line @cloudfour-no-param-reassign` in your code, or if you are manually enabling/configuring this rule. In either case, the migration path is to remove the rule configuration
+This change is breaking if you have `// eslint-disable-next-line @cloudfour/no-param-reassign` in your code, or if you are manually enabling/configuring this rule. In either case, the migration path is to remove the rule configuration

--- a/.changeset/tame-terms-cover.md
+++ b/.changeset/tame-terms-cover.md
@@ -1,0 +1,9 @@
+---
+'@cloudfour/eslint-plugin': major
+---
+
+Add support for linting TypeScript files
+
+If you have .ts or .tsx files, ESLint should automatically start linting them once you update.
+
+If typescript-eslint is unable to automatically infer your `tsconfig.json` location, you may need to [manually configure that](https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/TYPED_LINTING.md)


### PR DESCRIPTION
These unreleased changes were created before changesets was added to the project.

I added changeset files so that they get added to the changelog.

The file names are randomly generated, and the files will get combined into the changelog after the release PR is merged. The release PR will be made automatically once this PR is merged.