### PR TITLE
Disable rules from eslint-plugin-node that TS handles

### DIFF
--- a/.changeset/famous-foxes-know.md
+++ b/.changeset/famous-foxes-know.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/eslint-plugin': minor
+---
+
+Disable node/no-missing-_ rules for TS, so that it doesn't error for importing `_.ts` files

--- a/.changeset/famous-foxes-know.md
+++ b/.changeset/famous-foxes-know.md
@@ -2,4 +2,4 @@
 '@cloudfour/eslint-plugin': minor
 ---
 
-Disable node/no-missing-_ rules for TS, so that it doesn't error for importing `_.ts` files
+Disable `node/no-missing-*` rules for TS, so that it doesn't error for importing `*.ts` files

--- a/src/config.js
+++ b/src/config.js
@@ -176,7 +176,7 @@ module.exports.configs = {
           ...typescript.configs['recommended-requiring-type-checking'].rules,
           ...prettierTypescript.rules,
 
-          // TS handles checking these, and these rules are slow
+          // TS handles checking these
           'node/no-missing-import': 'off',
           'node/no-missing-require': 'off',
 

--- a/src/config.js
+++ b/src/config.js
@@ -176,7 +176,10 @@ module.exports.configs = {
           ...typescript.configs['recommended-requiring-type-checking'].rules,
           ...prettierTypescript.rules,
 
-          'node/no-extraneous-import': 'off', // TS checks this, this rule is slow
+          // TS handles checking these, and these rules are slow
+          'node/no-missing-import': 'off',
+          'node/no-missing-require': 'off',
+
           'no-import-assign': 'off', // TS handles this
 
           // With TS, the only reason to have a @param tag


### PR DESCRIPTION
I was working through changes necessary for [this PR](https://github.com/cloudfour/cloudfour.com-patterns/pull/900) and I noticed that these two linting rules were causing problems.

The problems happen in scenarios like this:

```ts
import './a'
```

If the `a` file is a `.ts` file, then the code is not actually a problem, but the [`node/no-missing-import`](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-missing-import.md) and [`node/no-missing-require`](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-missing-require.md) rules flag it as a problem, since they don't recognize `.ts` files. It is possible to configure those rules to support `.ts` files, but it is easier (and faster) to just rely on the typescript type checker to tell us if we import something that doesn't exist.