### PR TITLE
Make capitalized-comments ignore most commented code

### DIFF
--- a/.changeset/thick-walls-sort.md
+++ b/.changeset/thick-walls-sort.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/eslint-plugin': minor
+---
+
+Make capitalized-comments ignore most commented code

--- a/src/config.js
+++ b/src/config.js
@@ -135,6 +135,17 @@ module.exports.configs = {
         'prefer-template': 'error',
         'no-param-reassign': 'off', // We don't use `arguments`, and assigning to parameters can be useful
         'no-promise-executor-return': 'off', // Allow implicit return in promise executor
+        'capitalized-comments': [
+          'error',
+          'always',
+          {
+            ignorePattern:
+              'pragma|ignore|prettier-ignore|webpack\\w+:|c8|return|const|let|var|await|function|console',
+            ignoreInlineComments: true,
+            ignoreConsecutiveComments: true,
+          },
+        ],
+
         'node/no-unsupported-features/es-syntax': 'off', // Does not account for transpilation
         'node/no-unpublished-require': 'off', // Does not account for "build" scripts
         'node/shebang': 'off', // Tons of false positives


### PR DESCRIPTION
Before this PR:

When I would save a file that had commented-out code in it, ESLint would capitalize the first letter of the first line of the code. Then when I uncommented the code, I'd have to un-capitalize it. This is annoying.

This PR tries to reduce the likelihood of that happening by avoiding capitalizing comments that are most likely commented code.