### PR TITLE
Disable unicorn/prefer-node-protocol

### DIFF
--- a/.changeset/odd-owls-relate.md
+++ b/.changeset/odd-owls-relate.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/eslint-plugin': minor
+---
+
+Disable unicorn/prefer-node-protocol

--- a/src/config.js
+++ b/src/config.js
@@ -175,6 +175,11 @@ module.exports.configs = {
           // There isn't a good reason to force use of Number.POSITIVE_INFINITY instead of Infinity
           { checkInfinity: false },
         ],
+        // The node: protocol for imports is supported for imports starting in node 12
+        // and for require()'s starting in node 16.
+        // Since for most projects, we are transpiling imports to requires,
+        // This rule is not ready until we only support node 16+
+        'unicorn/prefer-node-protocol': 'off',
         // This rule suggests incorrect code with the destructured object is modified
         // That is a fairly common case, and it is too annoying to always disable the rule on each line
         'unicorn/consistent-destructuring': 'off',


### PR DESCRIPTION
I like this rule, I think it makes a lot of sense. But I think it is a little premature. On all 3 projects we've tried adopting it into, we've had issues, and ended up disabling it.

It makes more sense to disable it by default, and when we have projects that are node 16+ only, we can enable it there.

The node: protocol for imports is supported for imports starting in node 12 and for require()'s starting in node 16.
Since for most projects, we are transpiling imports to requires, this rule is not ready until we only support node 16+