### PR TITLE
Bump `eslint-plugin-import` version in the package.json to a version that supports eslint v8

### DIFF
--- a/.changeset/witty-ears-remember.md
+++ b/.changeset/witty-ears-remember.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/eslint-plugin': patch
+---
+
+Fix dependency version for eslint-plugin-import

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@babel/core": "^7.13.10",
         "@typescript-eslint/eslint-plugin": "^5.0.0",
         "@typescript-eslint/parser": "^5.0.0",
-        "eslint-plugin-import": "^2.14.0",
+        "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-jsdoc": "^38.0.0",
         "eslint-plugin-n": "^15.0.1",
         "eslint-plugin-promise": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@babel/core": "^7.13.10",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
-    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jsdoc": "^38.0.0",
     "eslint-plugin-n": "^15.0.1",
     "eslint-plugin-promise": "^6.0.0",


### PR DESCRIPTION
We were already using a newer version in package-lock but that doesn't get published, so package consumers could still be on an older version which would break.