### PR TITLE
Enforce using the node: protocol for imports to node built-in modules

### DIFF
--- a/.changeset/long-olives-give.md
+++ b/.changeset/long-olives-give.md
@@ -1,0 +1,13 @@
+---
+'@cloudfour/eslint-plugin': major
+---
+
+Enforce using the `node`: protocol for imports to node built-in modules ([`prefer-node-protocol`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/prefer-node-protocol.js)).
+
+❌ `require('fs')` -> ✅ `require('node:fs')`
+❌ `import * as fs from 'fs'` -> ✅ `import * as fs from 'node:fs'`
+
+The `import` form is supported in node v14.13.1+.
+The `require` form is supported in node v14.18.0+.
+
+It is auto-fixable.

--- a/.changeset/long-olives-give.md
+++ b/.changeset/long-olives-give.md
@@ -4,8 +4,8 @@
 
 Enforce using the `node`: protocol for imports to node built-in modules ([`prefer-node-protocol`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/prefer-node-protocol.js)).
 
-❌ `require('fs')` -> ✅ `require('node:fs')`
-❌ `import * as fs from 'fs'` -> ✅ `import * as fs from 'node:fs'`
+❌ `require('fs')` → ✅ `require('node:fs')`
+❌ `import * as fs from 'fs'` → ✅ `import * as fs from 'node:fs'`
 
 The `import` form is supported in node v14.13.1+.
 The `require` form is supported in node v14.18.0+.

--- a/generate-changeset.mjs
+++ b/generate-changeset.mjs
@@ -1,8 +1,8 @@
 // @ts-check
 
-import { spawn } from 'child_process';
-import { promises as fs } from 'fs';
-import { join } from 'path';
+import { spawn } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
 import kleur from 'kleur';
 import _writeChangeset from '@changesets/write';
 import prompts from 'prompts';

--- a/src/config.js
+++ b/src/config.js
@@ -172,11 +172,6 @@ module.exports.configs = {
           // There isn't a good reason to force use of Number.POSITIVE_INFINITY instead of Infinity
           { checkInfinity: false },
         ],
-        // The node: protocol for imports is supported for imports starting in node 12
-        // and for require()'s starting in node 16.
-        // Since for most projects, we are transpiling imports to requires,
-        // This rule is not ready until we only support node 16+
-        'unicorn/prefer-node-protocol': 'off',
         // This rule suggests incorrect code with the destructured object is modified
         // That is a fairly common case, and it is too annoying to always disable the rule on each line
         'unicorn/consistent-destructuring': 'off',


### PR DESCRIPTION
From the changeset:

> Enforce using the `node`: protocol for imports to node built-in modules ([`prefer-node-protocol`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/prefer-node-protocol.js)).
> 
> ❌ `require('fs')` → ✅ `require('node:fs')`
> ❌ `import * as fs from 'fs'` → ✅ `import * as fs from 'node:fs'`
> 
> The `import` form is supported in node v14.13.1+.
> The `require` form is supported in node v14.18.0+.
> 
> It is auto-fixable.

Previously we disabled the rule because it hadn't yet been backported to being supported in `require()`s in node 14 yet, but now it has been. Also, Jest supports it now.

Why this rule:

It makes it easy to distinguish between builtin modules and modules from npm. There are over 40 builtin modules and it is hard to keep track of them. If you see code like `require('inspector')` you might look for the documentation [on npm](https://www.npmjs.com/package/inspector) before realizing that you are actually referencing the node builtin module.

The `node:` prefix makes it unambiguous which modules are node's builtin modules.