### PR TITLE
Enforce file extension in import

### DIFF
--- a/.changeset/four-cooks-bow.md
+++ b/.changeset/four-cooks-bow.md
@@ -8,3 +8,5 @@ Enabled [`@cloudfour/n/file-extension-in-import`](https://github.com/weiran-zsd/
 ❌ `import * as foo from './foo'` → ✅ `import * as foo from './foo.js'`
 
 If the file that you are importing is a `.ts` file, you must import it as `.js`, because of a [decision that the TypeScript team made](https://github.com/microsoft/TypeScript/issues/16577#issuecomment-754941937).
+
+It is auto-fixable.

--- a/.changeset/four-cooks-bow.md
+++ b/.changeset/four-cooks-bow.md
@@ -1,0 +1,10 @@
+---
+'@cloudfour/eslint-plugin': major
+---
+
+Enabled [`@cloudfour/n/file-extension-in-import`](https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/file-extension-in-import.md).
+
+❌ `require('./foo')` → ✅ `require('./foo.js')`
+❌ `import * as foo from './foo'` → ✅ `import * as foo from './foo.js'`
+
+If the file that you are importing is a `.ts` file, you must import it as `.js`, because of a [decision that the TypeScript team made](https://github.com/microsoft/TypeScript/issues/16577#issuecomment-754941937).

--- a/fixtures/downshift/src/hooks/useCombobox/reducer.js
+++ b/fixtures/downshift/src/hooks/useCombobox/reducer.js
@@ -1,4 +1,4 @@
-import { getHighlightedIndexOnOpen, getDefaultValue } from '../utils';
+import { getHighlightedIndexOnOpen, getDefaultValue } from '../utils.js';
 import { getNextWrappingIndex, getNextNonDisabledIndex } from '../../utils';
 import * as stateChangeTypes from './stateChangeTypes';
 

--- a/fixtures/downshift/src/hooks/useCombobox/utils.js
+++ b/fixtures/downshift/src/hooks/useCombobox/utils.js
@@ -4,7 +4,7 @@ import {
   getElementIds as getElementIdsCommon,
   defaultProps as defaultPropsCommon,
   getInitialState as getInitialStateCommon,
-} from '../utils';
+} from '../utils.js';
 
 function getElementIds({ id, inputId, ...rest }) {
   const uniqueId = id === undefined ? `downshift-${generateId()}` : id;

--- a/fixtures/downshift/src/hooks/useSelect/reducer.js
+++ b/fixtures/downshift/src/hooks/useSelect/reducer.js
@@ -1,6 +1,6 @@
 import { getNextWrappingIndex, getNextNonDisabledIndex } from '../../utils';
-import { getHighlightedIndexOnOpen, getDefaultValue } from '../utils';
-import { getItemIndexByCharacterKey } from './utils';
+import { getHighlightedIndexOnOpen, getDefaultValue } from '../utils.js';
+import { getItemIndexByCharacterKey } from './utils.js';
 import * as stateChangeTypes from './stateChangeTypes';
 
 /* eslint-disable complexity */

--- a/fixtures/downshift/src/hooks/useSelect/utils.js
+++ b/fixtures/downshift/src/hooks/useSelect/utils.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { defaultProps as commonDefaultProps } from '../utils';
+import { defaultProps as commonDefaultProps } from '../utils.js';
 
 // eslint-disable-next-line max-params
 function getItemIndexByCharacterKey(

--- a/fixtures/rollup/rollup.config.js
+++ b/fixtures/rollup/rollup.config.js
@@ -11,7 +11,7 @@ import addCliEntry from './build-plugins/add-cli-entry.js';
 import conditionalFsEventsImport from './build-plugins/conditional-fsevents-import';
 import emitModulePackageFile from './build-plugins/emit-module-package-file.js';
 import esmDynamicImport from './build-plugins/esm-dynamic-import.js';
-import getLicenseHandler from './build-plugins/generate-license-file';
+import getLicenseHandler from './build-plugins/generate-license-file.js';
 import pkg from './package.json';
 
 const commitHash = (function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@typescript-eslint/parser": "^5.0.0",
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-jsdoc": "^39.0.0",
-        "eslint-plugin-n": "^15.0.1",
+        "eslint-plugin-n": "^15.2.1",
         "eslint-plugin-promise": "^6.0.0",
         "eslint-plugin-unicorn": "^42.0.0"
       },
@@ -1407,17 +1407,17 @@
       }
     },
     "node_modules/builtins": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/builtins/-/builtins-4.0.0.tgz",
-      "integrity": "sha512-qC0E2Dxgou1IHhvJSLwGDSTvokbRovU5zZFuDY6oY8Y2lF3nGt5Ad8YZK7GMtqzY84Wu7pXTPeHQeHcXSXsRhw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
       "dependencies": {
         "semver": "^7.0.0"
       }
     },
     "node_modules/builtins/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -2243,18 +2243,18 @@
       }
     },
     "node_modules/eslint-plugin-n": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.0.1.tgz",
-      "integrity": "sha512-w1vgnlS3Y3kd2Ye2YpQvWJppx6ViySIpBIcdlw1dBBaX3m1R/cdKHE3X2PWXhJdH88pmFy1a+04a6lMlo5D9EQ==",
+      "version": "15.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.2.1.tgz",
+      "integrity": "sha512-uMG50pvKqXK9ab163bSI5OpyZR0F5yIB0pEC4ciGpBLrXVjVDOlx5oTq8GQULWzbelJt7wL5Rw4T+FfAff5Cxg==",
       "dependencies": {
-        "builtins": "^4.0.0",
+        "builtins": "^5.0.1",
         "eslint-plugin-es": "^4.1.0",
         "eslint-utils": "^3.0.0",
         "ignore": "^5.1.1",
-        "is-core-module": "^2.3.0",
-        "minimatch": "^3.0.4",
+        "is-core-module": "^2.9.0",
+        "minimatch": "^3.1.2",
         "resolve": "^1.10.1",
-        "semver": "^6.3.0"
+        "semver": "^7.3.7"
       },
       "engines": {
         "node": ">=12.22.0"
@@ -2304,6 +2304,20 @@
       "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/eslint-plugin-n/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/eslint-plugin-promise": {
@@ -3134,9 +3148,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -6286,17 +6300,17 @@
       "integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA=="
     },
     "builtins": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/builtins/-/builtins-4.0.0.tgz",
-      "integrity": "sha512-qC0E2Dxgou1IHhvJSLwGDSTvokbRovU5zZFuDY6oY8Y2lF3nGt5Ad8YZK7GMtqzY84Wu7pXTPeHQeHcXSXsRhw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
       "requires": {
         "semver": "^7.0.0"
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -7015,18 +7029,18 @@
       }
     },
     "eslint-plugin-n": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.0.1.tgz",
-      "integrity": "sha512-w1vgnlS3Y3kd2Ye2YpQvWJppx6ViySIpBIcdlw1dBBaX3m1R/cdKHE3X2PWXhJdH88pmFy1a+04a6lMlo5D9EQ==",
+      "version": "15.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.2.1.tgz",
+      "integrity": "sha512-uMG50pvKqXK9ab163bSI5OpyZR0F5yIB0pEC4ciGpBLrXVjVDOlx5oTq8GQULWzbelJt7wL5Rw4T+FfAff5Cxg==",
       "requires": {
-        "builtins": "^4.0.0",
+        "builtins": "^5.0.1",
         "eslint-plugin-es": "^4.1.0",
         "eslint-utils": "^3.0.0",
         "ignore": "^5.1.1",
-        "is-core-module": "^2.3.0",
-        "minimatch": "^3.0.4",
+        "is-core-module": "^2.9.0",
+        "minimatch": "^3.1.2",
         "resolve": "^1.10.1",
-        "semver": "^6.3.0"
+        "semver": "^7.3.7"
       },
       "dependencies": {
         "eslint-plugin-es": {
@@ -7052,6 +7066,14 @@
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
           "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ=="
+        },
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         }
       }
     },
@@ -7554,9 +7576,9 @@
       }
     },
     "is-core-module": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
       "requires": {
         "has": "^1.0.3"
       }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@typescript-eslint/parser": "^5.0.0",
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jsdoc": "^39.0.0",
-    "eslint-plugin-n": "^15.0.1",
+    "eslint-plugin-n": "^15.2.1",
     "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-unicorn": "^42.0.0"
   },

--- a/src/config.js
+++ b/src/config.js
@@ -143,6 +143,7 @@ module.exports.configs = {
         'n/no-unsupported-features/es-syntax': 'off', // Does not account for transpilation
         'n/no-unpublished-require': 'off', // Does not account for "build" scripts
         'n/shebang': 'off', // Tons of false positives
+        'n/file-extension-in-import': ['error', 'always'], // Don't allow extension-less relative imports (e.g. use ./foo.js instead of ./foo)
 
         'unicorn/import-style': 'off', // It doesn't seem useful to force people to use named, default, or namespace imports
         'unicorn/prevent-abbreviations': 'off', // Causes more issues than it's worth


### PR DESCRIPTION
From the changeset:

> Enabled [`@cloudfour/n/file-extension-in-import`](https://github.com/weiran-zsd/eslint-plugin-node/blob/HEAD/docs/rules/file-extension-in-import.md).
> 
> ❌ `require('./foo')` → ✅ `require('./foo.js')`
> ❌ `import * as foo from './foo'` → ✅ `import * as foo from './foo.js'`
> 
> If the file that you are importing is a `.ts` file, you must import it as `.js`, because of a [decision that the TypeScript team made](https://github.com/microsoft/TypeScript/issues/16577#issuecomment-754941937).
> 
> It is auto-fixable.

History of extension-less imports:

- The Node Resolution Algorithm for CommonJS has a feature where when you `require()` paths it will look in several places for the module, until it finds one:
  ex: `require('./foo')` checks for:
  - `./foo`
  - `./foo.js`
  - `./foo.json`
  - `./foo.node`
  - `./foo/package.json` with `main` field
  - `./foo/index.js`
- People began implementing `require()` in browsers with bundlers (Browserify and then Webpack)
- ES6 Imports began to be proposed as a part of the JS language
- Bundlers (Browserify/Webpack) began supporting `import`/`export`, by using the same internal mechanisms as `require()`, meaning that they preserved the resolution algorithm used by `require()`.
- The ES Imports spec treats import paths as URL's (e.g. `import './foo'` resolves like `<a href="./foo"`). There is no mechanism for rewriting paths like `./foo` -> `./foo.js` (except if the server provides redirects)
- This means that the bundler's implementation of ES modules doesn't match the spec because they _do_ rewrite imports.
- Other bundlers and tools (`parcel`, `esbuild`, `rollup-plugin-node-resolve`, `typescript`) followed what webpack and browserify did, attempting to minimize compatibility issues when switching between bundlers.
- Browsers began implementing ES modules natively. According to the spec, there is no path rewriting.
- Node began implementing ES modules natively, following the spec. There is no path rewriting. This means that Node has a different resolution algorithm for `require` than `import`.
- TypeScript added support for opting-in to using Node's modern resolution with `import` statements by setting `moduleResolution` to `node12`. When that option is set, TypeScript will no longer resolve `import './foo'` to `./foo.js` or `./foo.ts`, and it will throw an error (same as Node). The TS team [decided](https://github.com/microsoft/TypeScript/issues/16577#issuecomment-754941937) that in order to import a file called `foo.ts`, you must use a `.js` import: `import './foo.js'`, even though the file `foo.js` does not exist. TS will not let you use `import './foo.ts'`, even though `./foo.ts` exists. The rationale is that if TS was to rewrite the import path during code emit from `.ts` to `.js`, it would be a functionality change to the JS code, which they avoid with a ten-foot pole. (I don't think this decision was the right one, but it is what it is).

In other words, syntax like `import './foo'` is syntax that was never really valid/specified. It is a mishmash of the ES import syntax and the CommonJS module specifier syntax. `require('./foo')` is valid and `import './foo.js'` is valid.

To help move our projects towards supporting native-node ESM and native-browser ESM, this PR enforces the use of file extensions in all path imports. That means it will switch `require('./foo')` to `require('./foo.js')` even though that change is not needed. The goal is consistency across all imports/requires, even in projects that use CommonJS or a bundler that shims in CommonJS resolution into ESM.