### PR TITLE
Revert changes to the `no-use-before-define` rule 

### DIFF
--- a/.changeset/tasty-spiders-occur.md
+++ b/.changeset/tasty-spiders-occur.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/eslint-plugin': minor
+---
+
+Revert changes to `no-use-before-define` rule since it was more heavy-handed than expected.

--- a/fixtures/babel/packages/babel-helper-create-class-features-plugin/src/fields.js
+++ b/fixtures/babel/packages/babel-helper-create-class-features-plugin/src/fields.js
@@ -1,0 +1,706 @@
+/* eslint-disable max-params */
+import { types as t, template, traverse } from '@babel/core';
+import memberExpressionToFunctions from '@babel/helper-member-expression-to-functions';
+import optimiseCall from '@babel/helper-optimise-call-expression';
+import ReplaceSupers, {
+  environmentVisitor,
+} from '@babel/helper-replace-supers';
+
+import * as ts from './typescript';
+
+export function buildPrivateNamesMap(props) {
+  const privateNamesMap = new Map();
+  for (const prop of props) {
+    const isPrivate = prop.isPrivate();
+    const isMethod = !prop.isProperty();
+    const isInstance = !prop.node.static;
+    if (isPrivate) {
+      const { name } = prop.node.key.id;
+      const update = privateNamesMap.has(name)
+        ? privateNamesMap.get(name)
+        : {
+            id: prop.scope.generateUidIdentifier(name),
+            static: !isInstance,
+            method: isMethod,
+          };
+      if (prop.node.kind === 'get') {
+        update.getId = prop.scope.generateUidIdentifier(`get_${name}`);
+      } else if (prop.node.kind === 'set') {
+        update.setId = prop.scope.generateUidIdentifier(`set_${name}`);
+      } else if (prop.node.kind === 'method') {
+        update.methodId = prop.scope.generateUidIdentifier(name);
+      }
+
+      privateNamesMap.set(name, update);
+    }
+  }
+
+  return privateNamesMap;
+}
+
+export function buildPrivateNamesNodes(privateNamesMap, loose, state) {
+  const initNodes = [];
+
+  for (const [name, value] of privateNamesMap) {
+    // In loose mode, both static and instance fields are transpiled using a
+    // secret non-enumerable property. Hence, we also need to generate that
+    // key (using the classPrivateFieldLooseKey helper).
+    // In spec mode, only instance fields need a "private name" initializer
+    // because static fields are directly assigned to a variable in the
+    // buildPrivateStaticFieldInitSpec function.
+    const { id, static: isStatic, method: isMethod, getId, setId } = value;
+    const isAccessor = getId || setId;
+    if (loose) {
+      initNodes.push(
+        template.statement.ast`
+          var ${id} = ${state.addHelper('classPrivateFieldLooseKey')}("${name}")
+        `
+      );
+    } else if (isMethod && !isStatic) {
+      if (isAccessor) {
+        initNodes.push(template.statement.ast`var ${id} = new WeakMap();`);
+      } else {
+        initNodes.push(template.statement.ast`var ${id} = new WeakSet();`);
+      }
+    } else if (!isStatic) {
+      initNodes.push(template.statement.ast`var ${id} = new WeakMap();`);
+    }
+  }
+
+  return initNodes;
+}
+
+// Traverses the class scope, handling private name references. If an inner
+// class redeclares the same private name, it will hand off traversal to the
+// restricted visitor (which doesn't traverse the inner class's inner scope).
+const privateNameVisitor = {
+  PrivateName(path) {
+    const { privateNamesMap } = this;
+    const { node, parentPath } = path;
+
+    if (!parentPath.isMemberExpression({ property: node })) return;
+    if (!privateNamesMap.has(node.id.name)) return;
+
+    this.handle(parentPath);
+  },
+
+  Class(path) {
+    const { privateNamesMap } = this;
+    const body = path.get('body.body');
+
+    for (const prop of body) {
+      if (!prop.isPrivate()) {
+        continue;
+      }
+
+      if (!privateNamesMap.has(prop.node.key.id.name)) continue;
+
+      // This class redeclares the private name.
+      // So, we can only evaluate the things in the outer scope.
+      path.traverse(privateNameInnerVisitor, this);
+      path.skip();
+      break;
+    }
+  },
+};
+
+// Traverses the outer portion of a class, without touching the class's inner
+// scope, for private names.
+const privateNameInnerVisitor = traverse.visitors.merge([
+  {
+    PrivateName: privateNameVisitor.PrivateName,
+  },
+  environmentVisitor,
+]);
+
+const privateNameHandlerSpec = {
+  memoise(member, count) {
+    const { scope } = member;
+    const { object } = member.node;
+
+    const memo = scope.maybeGenerateMemoised(object);
+    if (!memo) {
+      return;
+    }
+
+    this.memoiser.set(object, memo, count);
+  },
+
+  receiver(member) {
+    const { object } = member.node;
+
+    if (this.memoiser.has(object)) {
+      return t.cloneNode(this.memoiser.get(object));
+    }
+
+    return t.cloneNode(object);
+  },
+
+  get(member) {
+    const { classRef, privateNamesMap, file } = this;
+    const { name } = member.node.property.id;
+    const {
+      id,
+      static: isStatic,
+      method: isMethod,
+      methodId,
+      getId,
+      setId,
+    } = privateNamesMap.get(name);
+    const isAccessor = getId || setId;
+
+    if (isStatic) {
+      const helperName =
+        isMethod && !isAccessor
+          ? 'classStaticPrivateMethodGet'
+          : 'classStaticPrivateFieldSpecGet';
+
+      return t.callExpression(file.addHelper(helperName), [
+        this.receiver(member),
+        t.cloneNode(classRef),
+        t.cloneNode(id),
+      ]);
+    }
+
+    if (isMethod) {
+      if (isAccessor) {
+        return t.callExpression(file.addHelper('classPrivateFieldGet'), [
+          this.receiver(member),
+          t.cloneNode(id),
+        ]);
+      }
+
+      return t.callExpression(file.addHelper('classPrivateMethodGet'), [
+        this.receiver(member),
+        t.cloneNode(id),
+        t.cloneNode(methodId),
+      ]);
+    }
+
+    return t.callExpression(file.addHelper('classPrivateFieldGet'), [
+      this.receiver(member),
+      t.cloneNode(id),
+    ]);
+  },
+
+  set(member, value) {
+    const { classRef, privateNamesMap, file } = this;
+    const { name } = member.node.property.id;
+    const {
+      id,
+      static: isStatic,
+      method: isMethod,
+      setId,
+      getId,
+    } = privateNamesMap.get(name);
+    const isAccessor = getId || setId;
+
+    if (isStatic) {
+      const helperName =
+        isMethod && !isAccessor
+          ? 'classStaticPrivateMethodSet'
+          : 'classStaticPrivateFieldSpecSet';
+
+      return t.callExpression(file.addHelper(helperName), [
+        this.receiver(member),
+        t.cloneNode(classRef),
+        t.cloneNode(id),
+        value,
+      ]);
+    }
+
+    if (isMethod) {
+      if (setId) {
+        return t.callExpression(file.addHelper('classPrivateFieldSet'), [
+          this.receiver(member),
+          t.cloneNode(id),
+          value,
+        ]);
+      }
+
+      return t.callExpression(file.addHelper('classPrivateMethodSet'), []);
+    }
+
+    return t.callExpression(file.addHelper('classPrivateFieldSet'), [
+      this.receiver(member),
+      t.cloneNode(id),
+      value,
+    ]);
+  },
+
+  destructureSet(member) {
+    const { privateNamesMap, file } = this;
+    const { name } = member.node.property.id;
+    const { id } = privateNamesMap.get(name);
+    return t.memberExpression(
+      t.callExpression(file.addHelper('classPrivateFieldDestructureSet'), [
+        this.receiver(member),
+        t.cloneNode(id),
+      ]),
+      t.identifier('value')
+    );
+  },
+
+  call(member, args) {
+    // The first access (the get) should do the memo assignment.
+    this.memoise(member, 1);
+
+    return optimiseCall(this.get(member), this.receiver(member), args);
+  },
+};
+
+const privateNameHandlerLoose = {
+  handle(member) {
+    const { privateNamesMap, file } = this;
+    const { object } = member.node;
+    const { name } = member.node.property.id;
+
+    member.replaceWith(
+      template.expression`BASE(REF, PROP)[PROP]`({
+        BASE: file.addHelper('classPrivateFieldLooseBase'),
+        REF: object,
+        PROP: privateNamesMap.get(name).id,
+      })
+    );
+  },
+};
+
+export function transformPrivateNamesUsage(
+  ref,
+  path,
+  privateNamesMap,
+  loose,
+  state
+) {
+  const body = path.get('body');
+
+  if (loose) {
+    body.traverse(privateNameVisitor, {
+      privateNamesMap,
+      file: state,
+      ...privateNameHandlerLoose,
+    });
+  } else {
+    memberExpressionToFunctions(body, privateNameVisitor, {
+      privateNamesMap,
+      classRef: ref,
+      file: state,
+      ...privateNameHandlerSpec,
+    });
+  }
+}
+
+function buildPrivateFieldInitLoose(ref, prop, privateNamesMap) {
+  const { id } = privateNamesMap.get(prop.node.key.id.name);
+  const value = prop.node.value || prop.scope.buildUndefinedNode();
+
+  return template.statement.ast`
+    Object.defineProperty(${ref}, ${id}, {
+      // configurable is false by default
+      // enumerable is false by default
+      writable: true,
+      value: ${value}
+    });
+  `;
+}
+
+function buildPrivateInstanceFieldInitSpec(ref, prop, privateNamesMap) {
+  const { id } = privateNamesMap.get(prop.node.key.id.name);
+  const value = prop.node.value || prop.scope.buildUndefinedNode();
+
+  return template.statement.ast`${id}.set(${ref}, {
+    // configurable is always false for private elements
+    // enumerable is always false for private elements
+    writable: true,
+    value: ${value},
+  })`;
+}
+
+function buildPrivateStaticFieldInitSpec(prop, privateNamesMap) {
+  const privateName = privateNamesMap.get(prop.node.key.id.name);
+  const { id, getId, setId, initAdded } = privateName;
+  const isAccessor = getId || setId;
+
+  if (!prop.isProperty() && (initAdded || !isAccessor)) return;
+
+  if (isAccessor) {
+    privateNamesMap.set(prop.node.key.id.name, {
+      ...privateName,
+      initAdded: true,
+    });
+
+    return template.statement.ast`
+      var ${id.name} = {
+        // configurable is false by default
+        // enumerable is false by default
+        // writable is false by default
+        get: ${getId ? getId.name : prop.scope.buildUndefinedNode()},
+        set: ${setId ? setId.name : prop.scope.buildUndefinedNode()}
+      }
+    `;
+  }
+
+  const value = prop.node.value || prop.scope.buildUndefinedNode();
+  return template.statement.ast`
+    var ${id} = {
+      // configurable is false by default
+      // enumerable is false by default
+      writable: true,
+      value: ${value}
+    };
+  `;
+}
+
+function buildPrivateMethodInitLoose(ref, prop, privateNamesMap) {
+  const privateName = privateNamesMap.get(prop.node.key.id.name);
+  const { methodId, id, getId, setId, initAdded } = privateName;
+  if (initAdded) return;
+
+  if (methodId) {
+    return template.statement.ast`
+        Object.defineProperty(${ref}, ${id}, {
+          // configurable is false by default
+          // enumerable is false by default
+          // writable is false by default
+          value: ${methodId.name}
+        });
+      `;
+  }
+
+  const isAccessor = getId || setId;
+  if (isAccessor) {
+    privateNamesMap.set(prop.node.key.id.name, {
+      ...privateName,
+      initAdded: true,
+    });
+
+    return template.statement.ast`
+      Object.defineProperty(${ref}, ${id}, {
+        // configurable is false by default
+        // enumerable is false by default
+        // writable is false by default
+        get: ${getId ? getId.name : prop.scope.buildUndefinedNode()},
+        set: ${setId ? setId.name : prop.scope.buildUndefinedNode()}
+      });
+    `;
+  }
+}
+
+function buildPrivateInstanceMethodInitSpec(ref, prop, privateNamesMap) {
+  const privateName = privateNamesMap.get(prop.node.key.id.name);
+  const { id, getId, setId, initAdded } = privateName;
+
+  if (initAdded) return;
+
+  const isAccessor = getId || setId;
+  if (isAccessor) {
+    privateNamesMap.set(prop.node.key.id.name, {
+      ...privateName,
+      initAdded: true,
+    });
+
+    return template.statement.ast`
+      ${id}.set(${ref}, {
+        get: ${getId ? getId.name : prop.scope.buildUndefinedNode()},
+        set: ${setId ? setId.name : prop.scope.buildUndefinedNode()}
+      });
+    `;
+  }
+
+  return template.statement.ast`${id}.add(${ref})`;
+}
+
+function buildPublicFieldInitLoose(ref, prop) {
+  const { key, computed } = prop.node;
+  const value = prop.node.value || prop.scope.buildUndefinedNode();
+
+  return t.expressionStatement(
+    t.assignmentExpression(
+      '=',
+      t.memberExpression(ref, key, computed || t.isLiteral(key)),
+      value
+    )
+  );
+}
+
+function buildPublicFieldInitSpec(ref, prop, state) {
+  const { key, computed } = prop.node;
+  const value = prop.node.value || prop.scope.buildUndefinedNode();
+
+  return t.expressionStatement(
+    t.callExpression(state.addHelper('defineProperty'), [
+      ref,
+      computed || t.isLiteral(key) ? key : t.stringLiteral(key.name),
+      value,
+    ])
+  );
+}
+
+function buildPrivateStaticMethodInitLoose(ref, prop, state, privateNamesMap) {
+  const privateName = privateNamesMap.get(prop.node.key.id.name);
+  const { id, methodId, getId, setId, initAdded } = privateName;
+
+  if (initAdded) return;
+
+  const isAccessor = getId || setId;
+  if (isAccessor) {
+    privateNamesMap.set(prop.node.key.id.name, {
+      ...privateName,
+      initAdded: true,
+    });
+
+    return template.statement.ast`
+      Object.defineProperty(${ref}, ${id}, {
+        // configurable is false by default
+        // enumerable is false by default
+        // writable is false by default
+        get: ${getId ? getId.name : prop.scope.buildUndefinedNode()},
+        set: ${setId ? setId.name : prop.scope.buildUndefinedNode()}
+      })
+    `;
+  }
+
+  return template.statement.ast`
+    Object.defineProperty(${ref}, ${id}, {
+      // configurable is false by default
+      // enumerable is false by default
+      // writable is false by default
+      value: ${methodId.name}
+    });
+  `;
+}
+
+function buildPrivateMethodDeclaration(prop, privateNamesMap, loose = false) {
+  const privateName = privateNamesMap.get(prop.node.key.id.name);
+  const {
+    id,
+    methodId,
+    getId,
+    setId,
+    getterDeclared,
+    setterDeclared,
+    static: isStatic,
+  } = privateName;
+  const { params, body, generator, async } = prop.node;
+  const methodValue = t.functionExpression(
+    methodId,
+    params,
+    body,
+    generator,
+    async
+  );
+  const isGetter = getId && !getterDeclared && params.length === 0;
+  const isSetter = setId && !setterDeclared && params.length > 0;
+
+  if (isGetter) {
+    privateNamesMap.set(prop.node.key.id.name, {
+      ...privateName,
+      getterDeclared: true,
+    });
+    return t.variableDeclaration('var', [
+      t.variableDeclarator(getId, methodValue),
+    ]);
+  }
+
+  if (isSetter) {
+    privateNamesMap.set(prop.node.key.id.name, {
+      ...privateName,
+      setterDeclared: true,
+    });
+    return t.variableDeclaration('var', [
+      t.variableDeclarator(setId, methodValue),
+    ]);
+  }
+
+  if (isStatic && !loose) {
+    return t.variableDeclaration('var', [
+      t.variableDeclarator(
+        id,
+        t.functionExpression(id, params, body, generator, async)
+      ),
+    ]);
+  }
+
+  return t.variableDeclaration('var', [
+    t.variableDeclarator(methodId, methodValue),
+  ]);
+}
+
+const thisContextVisitor = traverse.visitors.merge([
+  {
+    ThisExpression(path, state) {
+      state.needsClassRef = true;
+      path.replaceWith(t.cloneNode(state.classRef));
+    },
+  },
+  environmentVisitor,
+]);
+
+function replaceThisContext(path, ref, superRef, file, loose) {
+  const state = { classRef: ref, needsClassRef: false };
+
+  const replacer = new ReplaceSupers({
+    methodPath: path,
+    isLoose: loose,
+    superRef,
+    file,
+    getObjectRef() {
+      state.needsClassRef = true;
+      return path.node.static
+        ? ref
+        : t.memberExpression(ref, t.identifier('prototype'));
+    },
+  });
+  replacer.replace();
+  if (path.isProperty()) {
+    path.traverse(thisContextVisitor, state);
+  }
+
+  return state.needsClassRef;
+}
+
+// eslint-disable-next-line complexity
+export function buildFieldsInitNodes(
+  ref,
+  superRef,
+  props,
+  privateNamesMap,
+  state,
+  loose
+) {
+  const staticNodes = [];
+  const instanceNodes = [];
+  let needsClassRef = false;
+
+  for (const prop of props) {
+    ts.assertFieldTransformed(prop);
+
+    const isStatic = prop.node.static;
+    const isInstance = !isStatic;
+    const isPrivate = prop.isPrivate();
+    const isPublic = !isPrivate;
+    const isField = prop.isProperty();
+    const isMethod = !isField;
+
+    if (isStatic || (isMethod && isPrivate)) {
+      const replaced = replaceThisContext(prop, ref, superRef, state, loose);
+      needsClassRef = needsClassRef || replaced;
+    }
+
+    switch (true) {
+      case isStatic && isPrivate && isField && loose:
+        needsClassRef = true;
+        staticNodes.push(
+          buildPrivateFieldInitLoose(t.cloneNode(ref), prop, privateNamesMap)
+        );
+        break;
+      case isStatic && isPrivate && isField && !loose:
+        needsClassRef = true;
+        staticNodes.push(
+          buildPrivateStaticFieldInitSpec(prop, privateNamesMap)
+        );
+        break;
+      case isStatic && isPublic && isField && loose:
+        needsClassRef = true;
+        staticNodes.push(buildPublicFieldInitLoose(t.cloneNode(ref), prop));
+        break;
+      case isStatic && isPublic && isField && !loose:
+        needsClassRef = true;
+        staticNodes.push(
+          buildPublicFieldInitSpec(t.cloneNode(ref), prop, state)
+        );
+        break;
+      case isInstance && isPrivate && isField && loose:
+        instanceNodes.push(
+          buildPrivateFieldInitLoose(t.thisExpression(), prop, privateNamesMap)
+        );
+        break;
+      case isInstance && isPrivate && isField && !loose:
+        instanceNodes.push(
+          buildPrivateInstanceFieldInitSpec(
+            t.thisExpression(),
+            prop,
+            privateNamesMap
+          )
+        );
+        break;
+      case isInstance && isPrivate && isMethod && loose:
+        instanceNodes.unshift(
+          buildPrivateMethodInitLoose(t.thisExpression(), prop, privateNamesMap)
+        );
+        staticNodes.push(
+          buildPrivateMethodDeclaration(prop, privateNamesMap, loose)
+        );
+        break;
+      case isInstance && isPrivate && isMethod && !loose:
+        instanceNodes.unshift(
+          buildPrivateInstanceMethodInitSpec(
+            t.thisExpression(),
+            prop,
+            privateNamesMap
+          )
+        );
+        staticNodes.push(
+          buildPrivateMethodDeclaration(prop, privateNamesMap, loose)
+        );
+        break;
+      case isStatic && isPrivate && isMethod && !loose:
+        needsClassRef = true;
+        staticNodes.push(
+          buildPrivateStaticFieldInitSpec(prop, privateNamesMap)
+        );
+        staticNodes.unshift(
+          buildPrivateMethodDeclaration(prop, privateNamesMap, loose)
+        );
+        break;
+      case isStatic && isPrivate && isMethod && loose:
+        needsClassRef = true;
+        staticNodes.push(
+          buildPrivateStaticMethodInitLoose(
+            t.cloneNode(ref),
+            prop,
+            state,
+            privateNamesMap
+          )
+        );
+        staticNodes.unshift(
+          buildPrivateMethodDeclaration(prop, privateNamesMap, loose)
+        );
+        break;
+      case isInstance && isPublic && isField && loose:
+        instanceNodes.push(buildPublicFieldInitLoose(t.thisExpression(), prop));
+        break;
+      case isInstance && isPublic && isField && !loose:
+        instanceNodes.push(
+          buildPublicFieldInitSpec(t.thisExpression(), prop, state)
+        );
+        break;
+      default:
+        throw new Error('Unreachable.');
+    }
+  }
+
+  return {
+    staticNodes: staticNodes.filter(Boolean),
+    instanceNodes: instanceNodes.filter(Boolean),
+    wrapClass(path) {
+      for (const prop of props) {
+        prop.remove();
+      }
+
+      if (!needsClassRef) return path;
+
+      if (path.isClassExpression()) {
+        path.scope.push({ id: ref });
+        path.replaceWith(
+          t.assignmentExpression('=', t.cloneNode(ref), path.node)
+        );
+      } else if (!path.node.id) {
+        // Anonymous class declaration
+        path.node.id = ref;
+      }
+
+      return path;
+    },
+  };
+}

--- a/fixtures/babel/packages/babel-plugin-transform-parameters/src/params.js
+++ b/fixtures/babel/packages/babel-plugin-transform-parameters/src/params.js
@@ -38,21 +38,6 @@ const iifeVisitor = {
   },
 };
 
-function buildScopeIIFE(shadowedParams, body) {
-  const args = [];
-  const params = [];
-
-  for (const name of shadowedParams) {
-    // We create them twice; the other option is to use t.cloneNode
-    args.push(t.identifier(name));
-    params.push(t.identifier(name));
-  }
-
-  return t.returnStatement(
-    t.callExpression(t.arrowFunctionExpression(params, body), params)
-  );
-}
-
 // eslint-disable-next-line complexity
 export default function convertFunctionParams(path, loose) {
   const params = path.get('params');
@@ -204,4 +189,19 @@ export default function convertFunctionParams(path, loose) {
   }
 
   return true;
+}
+
+function buildScopeIIFE(shadowedParams, body) {
+  const args = [];
+  const params = [];
+
+  for (const name of shadowedParams) {
+    // We create them twice; the other option is to use t.cloneNode
+    args.push(t.identifier(name));
+    params.push(t.identifier(name));
+  }
+
+  return t.returnStatement(
+    t.callExpression(t.arrowFunctionExpression(params, body), params)
+  );
 }

--- a/fixtures/babel/packages/babel-plugin-transform-runtime/scripts/build-dist.js
+++ b/fixtures/babel/packages/babel-plugin-transform-runtime/scripts/build-dist.js
@@ -1,0 +1,223 @@
+'use strict';
+
+const path = require('path');
+
+const babel = require('@babel/core');
+const helpers = require('@babel/helpers');
+const runtimeVersion = require('@babel/runtime/package.json').version;
+const template = require('@babel/template');
+const t = require('@babel/types');
+const outputFile = require('output-file-sync');
+
+const transformRuntime = require('..');
+const corejs2Definitions =
+  require('../lib/runtime-corejs2-definitions').default();
+const corejs3Definitions =
+  require('../lib/runtime-corejs3-definitions').default();
+
+writeHelpers('@babel/runtime');
+writeHelpers('@babel/runtime-corejs2', { corejs: 2 });
+writeHelpers('@babel/runtime-corejs3', {
+  corejs: { version: 3, proposals: true },
+});
+
+writeCoreJS({
+  corejs: 2,
+  proposals: true,
+  definitions: corejs2Definitions,
+  paths: [
+    'is-iterable',
+    'get-iterator',
+    // This was previously in definitions, but was removed to work around
+    // zloirock/core-js#262. We need to keep it in @babel/runtime-corejs2 to
+    // avoid a breaking change there.
+    'symbol/async-iterator',
+  ],
+  corejsRoot: 'core-js/library/fn',
+});
+writeCoreJS({
+  corejs: 3,
+  proposals: false,
+  definitions: corejs3Definitions,
+  paths: [],
+  corejsRoot: 'core-js-pure/stable',
+});
+writeCoreJS({
+  corejs: 3,
+  proposals: true,
+  definitions: corejs3Definitions,
+  paths: ['is-iterable', 'get-iterator', 'get-iterator-method'],
+  corejsRoot: 'core-js-pure/features',
+});
+
+function writeCoreJS({
+  corejs,
+  proposals,
+  definitions: { BuiltIns, StaticProperties, InstanceProperties },
+  paths,
+  corejsRoot,
+}) {
+  const pkgDirname = getRuntimeRoot(`@babel/runtime-corejs${corejs}`);
+
+  for (const name of Object.keys(BuiltIns)) {
+    const { stable, path } = BuiltIns[name];
+    if (stable || proposals) paths.push(path);
+  }
+
+  for (const builtin of Object.keys(StaticProperties)) {
+    const props = StaticProperties[builtin];
+    for (const name of Object.keys(props)) {
+      const { stable, path } = props[name];
+      if (stable || proposals) paths.push(path);
+    }
+  }
+
+  if (InstanceProperties) {
+    for (const name of Object.keys(InstanceProperties)) {
+      const { stable, path } = InstanceProperties[name];
+      if (stable || proposals) paths.push(`instance/${path}`);
+    }
+  }
+
+  const runtimeRoot = proposals ? 'core-js' : 'core-js-stable';
+  for (const corejsPath of paths) {
+    outputFile(
+      path.join(pkgDirname, runtimeRoot, `${corejsPath}.js`),
+      `module.exports = require("${corejsRoot}/${corejsPath}");`
+    );
+  }
+}
+
+function writeHelpers(runtimeName, { corejs } = {}) {
+  writeHelperFiles(runtimeName, { corejs, esm: false });
+  writeHelperFiles(runtimeName, { corejs, esm: true });
+}
+
+function writeHelperFiles(runtimeName, { esm, corejs }) {
+  const pkgDirname = getRuntimeRoot(runtimeName);
+
+  for (const helperName of helpers.list) {
+    const helperFilename = path.join(
+      pkgDirname,
+      'helpers',
+      esm ? 'esm' : '',
+      `${helperName}.js`
+    );
+
+    outputFile(
+      helperFilename,
+      buildHelper(runtimeName, pkgDirname, helperFilename, helperName, {
+        esm,
+        corejs,
+      })
+    );
+  }
+}
+
+function getRuntimeRoot(runtimeName) {
+  return path.resolve(
+    __dirname,
+    '..',
+    '..',
+    runtimeName.replace(/^@babel\//, 'babel-')
+  );
+}
+
+// eslint-disable-next-line max-params
+function buildHelper(
+  runtimeName,
+  pkgDirname,
+  helperFilename,
+  helperName,
+  { esm, corejs }
+) {
+  const tree = t.program([], [], esm ? 'module' : 'script');
+  const dependencies = {};
+  let bindings = null;
+
+  if (!esm) {
+    bindings = [];
+    helpers.ensure(helperName, babel.File);
+    for (const dep of helpers.getDependencies(helperName)) {
+      // eslint-disable-next-line no-multi-assign
+      const id = (dependencies[dep] = t.identifier(t.toIdentifier(dep)));
+      tree.body.push(template.statement.ast`
+        var ${id} = require("${`./${dep}`}");
+      `);
+      bindings.push(id.name);
+    }
+  }
+
+  const helper = helpers.get(
+    helperName,
+    (dep) => dependencies[dep],
+    esm ? null : template.expression.ast`module.exports`,
+    bindings
+  );
+  tree.body.push(...helper.nodes);
+
+  return babel.transformFromAst(tree, null, {
+    filename: helperFilename,
+    presets: [
+      [
+        '@babel/preset-env',
+        { modules: false, exclude: ['@babel/plugin-transform-typeof-symbol'] },
+      ],
+    ],
+    plugins: [
+      [
+        transformRuntime,
+        { corejs, useESModules: esm, version: runtimeVersion },
+      ],
+      buildRuntimeRewritePlugin(
+        runtimeName,
+        path.relative(path.dirname(helperFilename), pkgDirname),
+        helperName
+      ),
+    ],
+    overrides: [
+      {
+        exclude: /typeof/,
+        plugins: ['@babel/plugin-transform-typeof-symbol'],
+      },
+    ],
+  }).code;
+}
+
+function buildRuntimeRewritePlugin(runtimeName, relativePath, helperName) {
+  function adjustImportPath(node, relativePath) {
+    node.value = helpers.list.includes(node.value)
+      ? `./${node.value}`
+      : node.value.replace(`${runtimeName}/`, `${relativePath}/`);
+  }
+
+  return {
+    pre(file) {
+      const original = file.get('helperGenerator');
+      file.set('helperGenerator', (name) => {
+        // Make sure that helpers won't insert circular references to themselves
+        if (name === helperName) return false;
+
+        return original(name);
+      });
+    },
+    visitor: {
+      ImportDeclaration(path) {
+        adjustImportPath(path.get('source').node, relativePath);
+      },
+      CallExpression(path) {
+        if (
+          !path.get('callee').isIdentifier({ name: 'require' }) ||
+          path.get('arguments').length !== 1 ||
+          !path.get('arguments')[0].isStringLiteral()
+        ) {
+          return;
+        }
+
+        // Replace any reference to @babel/runtime and other helpers
+        // with a relative path
+        adjustImportPath(path.get('arguments')[0].node, relativePath);
+      },
+    },
+  };
+}

--- a/fixtures/dom-testing-library/src/events.js
+++ b/fixtures/dom-testing-library/src/events.js
@@ -1,22 +1,4 @@
 import { getWindowFromNode } from './helpers';
-
-// Function written after some investigation here:
-// https://github.com/facebook/react/issues/10135#issuecomment-401496776
-function setNativeValue(element, value) {
-  const { set: valueSetter } =
-    Object.getOwnPropertyDescriptor(element, 'value') || {};
-  const prototype = Object.getPrototypeOf(element);
-  const { set: prototypeValueSetter } =
-    Object.getOwnPropertyDescriptor(prototype, 'value') || {};
-  if (prototypeValueSetter && valueSetter !== prototypeValueSetter) {
-    prototypeValueSetter.call(element, value);
-  } /* istanbul ignore next (I don't want to bother) */ else if (valueSetter) {
-    valueSetter.call(element, value);
-  } else {
-    throw new Error('The given element does not have a value setter');
-  }
-}
-
 const eventMap = {
   // Clipboard Events
   copy: {
@@ -436,6 +418,23 @@ for (const key of Object.keys(eventMap)) {
 
   fireEvent[key] = (node, init) =>
     fireEvent(node, createEvent[key](node, init));
+}
+
+// Function written after some investigation here:
+// https://github.com/facebook/react/issues/10135#issuecomment-401496776
+function setNativeValue(element, value) {
+  const { set: valueSetter } =
+    Object.getOwnPropertyDescriptor(element, 'value') || {};
+  const prototype = Object.getPrototypeOf(element);
+  const { set: prototypeValueSetter } =
+    Object.getOwnPropertyDescriptor(prototype, 'value') || {};
+  if (prototypeValueSetter && valueSetter !== prototypeValueSetter) {
+    prototypeValueSetter.call(element, value);
+  } /* istanbul ignore next (I don't want to bother) */ else if (valueSetter) {
+    valueSetter.call(element, value);
+  } else {
+    throw new Error('The given element does not have a value setter');
+  }
 }
 
 for (const aliasKey of Object.keys(eventAliasMap)) {

--- a/fixtures/dom-testing-library/src/wait-for-dom-change.js
+++ b/fixtures/dom-testing-library/src/wait-for-dom-change.js
@@ -1,0 +1,65 @@
+import { getConfig } from './config';
+import {
+  clearTimeout,
+  getDocument,
+  getWindowFromNode,
+  runWithRealTimers,
+  setImmediate,
+  setTimeout,
+} from './helpers';
+
+let hasWarned = false;
+
+// Deprecated... TODO: remove this method. People should use wait instead
+// the reasoning is that waiting for just any DOM change is an implementation
+// detail. People should be waiting for a specific thing to change.
+function waitForDomChange({
+  container = getDocument(),
+  timeout = getConfig().asyncUtilTimeout,
+  mutationObserverOptions = {
+    subtree: true,
+    childList: true,
+    attributes: true,
+    characterData: true,
+  },
+} = {}) {
+  if (!hasWarned) {
+    hasWarned = true;
+    console.warn(
+      `\`waitForDomChange\` has been deprecated. Use \`waitFor\` instead: https://testing-library.com/docs/dom-testing-library/api-async#waitfor.`
+    );
+  }
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(onTimeout, timeout);
+    const { MutationObserver } = getWindowFromNode(container);
+    const observer = new MutationObserver(onMutation);
+    runWithRealTimers(() =>
+      observer.observe(container, mutationObserverOptions)
+    );
+
+    function onDone(error, result) {
+      clearTimeout(timer);
+      setImmediate(() => observer.disconnect());
+      if (error) {
+        reject(error);
+      } else {
+        resolve(result);
+      }
+    }
+
+    function onMutation(mutationsList) {
+      onDone(null, mutationsList);
+    }
+
+    function onTimeout() {
+      onDone(new Error('Timed out in waitForDomChange.'), null);
+    }
+  });
+}
+
+function waitForDomChangeWrapper(...args) {
+  return getConfig().asyncWrapper(() => waitForDomChange(...args));
+}
+
+export { waitForDomChangeWrapper as waitForDomChange };

--- a/fixtures/mocha/karma.conf.js
+++ b/fixtures/mocha/karma.conf.js
@@ -15,42 +15,6 @@ const browserPlatformPairs = {
   'safari@latest': 'macOS 10.13',
 };
 
-function addSauceTests(cfg) {
-  cfg.reporters.push('saucelabs');
-  const browsers = Object.keys(browserPlatformPairs);
-  cfg.browsers = [...cfg.browsers, ...browsers];
-  cfg.customLaunchers = browsers.reduce((acc, browser) => {
-    const platform = browserPlatformPairs[browser];
-    const [browserName, version] = browser.split('@');
-    acc[browser] = {
-      base: 'SauceLabs',
-      browserName,
-      version,
-      platform,
-    };
-    return acc;
-  }, cfg.customLaunchers);
-
-  // See https://github.com/karma-runner/karma-sauce-launcher
-  // See https://github.com/bermi/sauce-connect-launcher#advanced-usage
-  Object.assign(cfg.sauceLabs, {
-    public: 'public',
-    connectOptions: {
-      connectRetries: 2,
-      connectRetryTimeout: 30_000,
-      detached: cfg.sauceLabs.startConnect,
-      tunnelIdentifier: cfg.sauceLabs.tunnelIdentifier,
-    },
-  });
-
-  cfg.concurrency = Infinity;
-  cfg.retryLimit = 1;
-
-  // For slow browser booting, ostensibly
-  cfg.captureTimeout = 120_000;
-  cfg.browserNoActivityTimeout = 20_000;
-}
-
 module.exports = (config) => {
   let bundleDirpath;
   const cfg = {
@@ -206,3 +170,39 @@ module.exports = (config) => {
 
   config.set(cfg);
 };
+
+function addSauceTests(cfg) {
+  cfg.reporters.push('saucelabs');
+  const browsers = Object.keys(browserPlatformPairs);
+  cfg.browsers = [...cfg.browsers, ...browsers];
+  cfg.customLaunchers = browsers.reduce((acc, browser) => {
+    const platform = browserPlatformPairs[browser];
+    const [browserName, version] = browser.split('@');
+    acc[browser] = {
+      base: 'SauceLabs',
+      browserName,
+      version,
+      platform,
+    };
+    return acc;
+  }, cfg.customLaunchers);
+
+  // See https://github.com/karma-runner/karma-sauce-launcher
+  // See https://github.com/bermi/sauce-connect-launcher#advanced-usage
+  Object.assign(cfg.sauceLabs, {
+    public: 'public',
+    connectOptions: {
+      connectRetries: 2,
+      connectRetryTimeout: 30_000,
+      detached: cfg.sauceLabs.startConnect,
+      tunnelIdentifier: cfg.sauceLabs.tunnelIdentifier,
+    },
+  });
+
+  cfg.concurrency = Infinity;
+  cfg.retryLimit = 1;
+
+  // For slow browser booting, ostensibly
+  cfg.captureTimeout = 120_000;
+  cfg.browserNoActivityTimeout = 20_000;
+}

--- a/fixtures/mocha/lib/growl.js
+++ b/fixtures/mocha/lib/growl.js
@@ -13,31 +13,40 @@ const { sync: which } = require('which');
 const { EVENT_RUN_END } = require('./runner').constants;
 
 /**
- * Returns Mocha logo image path.
- *
- * @private
- * @returns {string} Pathname of Mocha logo
+ * @summary
+ * Checks if Growl notification support seems likely.
+ * @description
+ * Glosses over the distinction between an unsupported platform
+ * and one that lacks prerequisite software installations.
+ * @public
+ * @see {@link https://github.com/tj/node-growl/blob/master/README.md|Prerequisite Installs}
+ * @see {@link Mocha#growl}
+ * @see {@link Mocha#isGrowlCapable}
+ * @returns {boolean} whether Growl notification support can be expected
  */
-const logo = () => path.join(__dirname, '..', 'assets', 'mocha-logo-96.png');
+exports.isCapable = () => {
+  if (!process.browser) {
+    return getSupportBinaries().reduce(
+      (acc, binary) => acc || Boolean(which(binary, { nothrow: true })),
+      false
+    );
+  }
+
+  return false;
+};
 
 /**
- * @summary
- * Callback for result of attempted Growl notification.
- * @description
- * Despite its appearance, this is <strong>not</strong> an Error-first
- * callback -- all parameters are populated regardless of success.
- * @private
- * @callback Growl~growlCB
- * @param {any} err - Error object, or <code>null</code> if successful.
+ * Implements desktop notifications as a pseudo-reporter.
+ *
+ * @public
+ * @see {@link Mocha#_growl}
+ * @param {Runner} runner - Runner instance.
  */
-function onCompletion(err) {
-  if (err) {
-    // As notifications are tangential to our purpose, just log the error.
-    const message =
-      err.code === 'ENOENT' ? 'prerequisite software not found' : err.message;
-    console.error('notification error:', message);
-  }
-}
+exports.notify = (runner) => {
+  runner.once(EVENT_RUN_END, () => {
+    display(runner);
+  });
+};
 
 /**
  * Displays the notification.
@@ -77,6 +86,33 @@ const display = (runner) => {
 
 /**
  * @summary
+ * Callback for result of attempted Growl notification.
+ * @description
+ * Despite its appearance, this is <strong>not</strong> an Error-first
+ * callback -- all parameters are populated regardless of success.
+ * @private
+ * @callback Growl~growlCB
+ * @param {any} err - Error object, or <code>null</code> if successful.
+ */
+function onCompletion(err) {
+  if (err) {
+    // As notifications are tangential to our purpose, just log the error.
+    const message =
+      err.code === 'ENOENT' ? 'prerequisite software not found' : err.message;
+    console.error('notification error:', message);
+  }
+}
+
+/**
+ * Returns Mocha logo image path.
+ *
+ * @private
+ * @returns {string} Pathname of Mocha logo
+ */
+const logo = () => path.join(__dirname, '..', 'assets', 'mocha-logo-96.png');
+
+/**
+ * @summary
  * Gets platform-specific Growl support binaries.
  * @description
  * Somewhat brittle dependency on `growl` package implementation, but it
@@ -92,40 +128,4 @@ const getSupportBinaries = () => {
     Windows_NT: ['growlnotify.exe'],
   };
   return binaries[os.type()] || [];
-};
-
-/**
- * @summary
- * Checks if Growl notification support seems likely.
- * @description
- * Glosses over the distinction between an unsupported platform
- * and one that lacks prerequisite software installations.
- * @public
- * @see {@link https://github.com/tj/node-growl/blob/master/README.md|Prerequisite Installs}
- * @see {@link Mocha#growl}
- * @see {@link Mocha#isGrowlCapable}
- * @returns {boolean} whether Growl notification support can be expected
- */
-exports.isCapable = () => {
-  if (!process.browser) {
-    return getSupportBinaries().reduce(
-      (acc, binary) => acc || Boolean(which(binary, { nothrow: true })),
-      false
-    );
-  }
-
-  return false;
-};
-
-/**
- * Implements desktop notifications as a pseudo-reporter.
- *
- * @public
- * @see {@link Mocha#_growl}
- * @param {Runner} runner - Runner instance.
- */
-exports.notify = (runner) => {
-  runner.once(EVENT_RUN_END, () => {
-    display(runner);
-  });
 };

--- a/src/config.js
+++ b/src/config.js
@@ -128,7 +128,6 @@ module.exports.configs = {
         'prefer-template': 'error',
         'no-param-reassign': 'off', // We don't use `arguments`, and assigning to parameters can be useful
         'no-promise-executor-return': 'off', // Allow implicit return in promise executor
-        'no-use-before-define': ['error'],
         'capitalized-comments': [
           'error',
           'always',
@@ -272,7 +271,15 @@ module.exports.configs = {
           '@typescript-eslint/no-unused-expressions': ['error'], // This rule is like the built in ESLint rule but it supports optional chaining
           // Replacing the built-in rule with the version that works well with TS
           'no-use-before-define': 'off',
-          '@typescript-eslint/no-use-before-define': ['error'],
+          '@typescript-eslint/no-use-before-define': [
+            'error',
+            {
+              functions: false,
+              classes: false,
+              variables: false,
+              ignoreTypeReferences: true,
+            },
+          ],
         }),
       },
     ],

--- a/src/rules/prefer-early-return/index.js
+++ b/src/rules/prefer-early-return/index.js
@@ -1,13 +1,4 @@
 /** @type {import('eslint').Rule.RuleModule} */
-
-/**
- * @param {import('estree').Statement} statement
- * @returns {statement is import('estree').IfStatement}
- */
-function isLonelyIfStatement(statement) {
-  return statement.type === 'IfStatement' && statement.alternate === null;
-}
-
 module.exports = {
   meta: {
     docs: {
@@ -80,3 +71,11 @@ module.exports = {
     };
   },
 };
+
+/**
+ * @param {import('estree').Statement} statement
+ * @returns {statement is import('estree').IfStatement}
+ */
+function isLonelyIfStatement(statement) {
+  return statement.type === 'IfStatement' && statement.alternate === null;
+}


### PR DESCRIPTION
This PR reverts the previous change to the to `no-use-before-define` rule since it was more heavy-handed than expected.

I used `git revert` to commit the PR commit and then created a new changeset. There were some conflicts when reverting the changes to `generate-changeset`. I ended up just backing out those changes since the changes I was reverting were minor and totally fine.

Let me know if there's another way you'd prefer I handle this.