### PR TITLE
Drop support for node 16

### DIFF
--- a/.changeset/sweet-mugs-shake.md
+++ b/.changeset/sweet-mugs-shake.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/eslint-plugin': major
+---
+
+Drop support for node 16. Now only node 18+ is supported

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 16
+      - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - name: Cache node modules
         uses: actions/cache@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
           # Fetch all git history for correct changelog commits
           fetch-depth: 0
 
-      - name: Setup Node.js 16.x
+      - name: Setup Node.js 18.x
         uses: actions/setup-node@master
         with:
-          node-version: 16.x
+          node-version: 18.x
 
       - name: Install Dependencies
         run: npm ci

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "!src/rules/**/*.test.js"
   ],
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "keywords": [
     "eslint",


### PR DESCRIPTION
Node 16 is EOL as of last week. Hoping this might fix https://github.com/cloudfour/eslint-config/pull/566#issuecomment-1726458063 since it looks like renovate is using npm@10, and npm@10 only supports node 18+.

Not sure if this will fix it though since renovate's update process doesn't depend on GH actions and might not read the `engines` field in package.json