### PR TITLE
Add tests for config behavior

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,5 @@ jobs:
         run: npm ci
       - name: Run Lint
         run: npm run lint:check
+      - name: Run Tests
+        run: npm test

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+# Fixtures must stay byte-stable: reformatting them would silently change which
+# rules fire, and the invalid fixtures are deliberately badly formatted.
+__tests__/fixtures/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @cloudfour/eslint-plugin
 
+## Unreleased
+
+### Breaking Changes
+
+- Narrow the supported Node versions from `>=22.16.0` to `^22.16.0 || >=24`. Node `23.x` was never really supported: `eslint-plugin-jsdoc` already excluded it, and `import.meta.dirname` was never backported to that line.
+
+### Minor Changes
+
+- Only publish `eslint.config.js` and `src/` to npm. The package previously also shipped repository files such as `.editorconfig`, `.nvmrc`, `.renovaterc.json` and the CI workflow.
+
 ## 25.0.1 - 2026-02-12
 
 ### Minor Changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,35 @@
 # Contributing Guide
 
+## Tests
+
+```sh
+npm test          # run once
+npm run test:watch
+```
+
+The suite uses [`node --test`](https://nodejs.org/api/test.html), so there is no
+test framework to install. It covers four things:
+
+- **Fixture behaviour** (`__tests__/javascript.test.js`, `__tests__/typescript.test.js`)
+  lints `__tests__/fixtures/` with our config and asserts the exact set of rules
+  that fire. The `valid` fixtures are the interesting half: everything in them is
+  something we deliberately allow, so they fail if a dependency re-enables a rule
+  we turned off.
+- **Node support** (`__tests__/engines.test.js`) asserts that every Node version
+  we advertise in `engines.node` is one that each installed dependency also
+  supports.
+- **Prettier conflicts** (`__tests__/prettier-conflicts.test.js`) runs the
+  `eslint-config-prettier` CLI, which reports any enabled rule that fights
+  Prettier.
+- **Deprecations** (`__tests__/deprecated-rules.test.js`) fails when a dependency
+  bump deprecates a rule we still enable.
+
+When a dependency bump changes which rules fire, that is a real behaviour change
+for consumers: update the fixtures and record it in `CHANGELOG.md`.
+
+Fixtures are excluded from ESLint and Prettier so that autofixing can never
+silently change what they test.
+
 ## Release Process
 
 [How to publish an updated version](https://cloudfour.com/thinks/how-to-publish-an-updated-version-of-an-npm-package/)

--- a/__tests__/deprecated-rules.test.js
+++ b/__tests__/deprecated-rules.test.js
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { ESLint } from 'eslint';
+import { builtinRules } from 'eslint/use-at-your-own-risk';
+
+import config from '../eslint.config.js';
+
+// Rules we knowingly still enable despite upstream deprecating them. Most come
+// from the vendored copy of eslint-config-standard in src/, which predates the
+// deprecations. This list is a canary, not a target: it should only ever shrink.
+// When a dependency bump deprecates something new, this test fails and tells us
+// to decide about it deliberately rather than finding out from a consumer.
+const KNOWN_DEPRECATED = [
+	'lines-between-class-members',
+	'no-buffer-constructor',
+	'no-new-object',
+	'no-new-symbol',
+	'no-return-await',
+	'spaced-comment',
+];
+
+/** Maps every rule available to our config to its metadata. */
+const ruleMeta = new Map(
+	[...builtinRules].map(([name, rule]) => [name, rule.meta]),
+);
+for (const entry of config) {
+	for (const [prefix, plugin] of Object.entries(entry.plugins ?? {})) {
+		for (const [name, rule] of Object.entries(plugin.rules ?? {})) {
+			ruleMeta.set(`${prefix}/${name}`, rule.meta);
+		}
+	}
+}
+
+const activeRules = async (filePath) => {
+	const eslint = new ESLint({
+		overrideConfigFile: true,
+		overrideConfig: config,
+	});
+	const resolved = await eslint.calculateConfigForFile(filePath);
+
+	return Object.entries(resolved.rules)
+		.filter(([, entry]) => (Array.isArray(entry) ? entry[0] : entry) !== 0)
+		.map(([name]) => name);
+};
+
+describe('deprecated rules', () => {
+	for (const filePath of ['probe.js', 'probe.ts']) {
+		it(`enables no newly deprecated rules for ${filePath}`, async () => {
+			const rules = await activeRules(filePath);
+			const deprecated = rules
+				.filter((name) => ruleMeta.get(name)?.deprecated)
+				.filter((name) => !KNOWN_DEPRECATED.includes(name))
+				.toSorted();
+
+			assert.deepEqual(deprecated, []);
+		});
+	}
+
+	it('has no stale entries in the known-deprecated list', async () => {
+		const js = await activeRules('probe.js');
+		const ts = await activeRules('probe.ts');
+		const deprecated = new Set(
+			[...js, ...ts].filter((name) => ruleMeta.get(name)?.deprecated),
+		);
+		const stale = KNOWN_DEPRECATED.filter((name) => !deprecated.has(name));
+
+		assert.deepEqual(
+			stale,
+			[],
+			'These rules are no longer enabled or no longer deprecated. Remove them from KNOWN_DEPRECATED.',
+		);
+	});
+});

--- a/__tests__/engines.test.js
+++ b/__tests__/engines.test.js
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+
+// The semver package is CommonJS, so its helpers come off the default export.
+import semver from 'semver';
+
+const readPackage = (path) => JSON.parse(readFileSync(path, 'utf8'));
+
+const pkg = readPackage('package.json');
+
+// Read what is actually installed rather than querying the registry: this tests
+// the tree CI resolves from the lockfile, needs no network, and stays
+// deterministic. A Renovate PR that bumps a dependency into a narrower Node
+// range fails here instead of silently shipping a range we cannot honour.
+const dependencies = Object.keys({
+	...pkg.dependencies,
+	...pkg.devDependencies,
+})
+	.map((name) => ({
+		name,
+		range: readPackage(`node_modules/${name}/package.json`).engines?.node,
+	}))
+	.filter((dependency) => dependency.range !== undefined);
+
+describe('engines.node', () => {
+	it('has dependencies installed to check against', () => {
+		assert.ok(dependencies.length > 0);
+	});
+
+	for (const { name, range } of dependencies) {
+		it(`is a range ${name} also supports`, () => {
+			assert.ok(
+				semver.subset(pkg.engines.node, range),
+				`We declare "${pkg.engines.node}" but ${name} only supports "${range}", ` +
+					`so there are Node versions we claim to support that it does not.`,
+			);
+		});
+	}
+});

--- a/__tests__/fixtures/invalid.js
+++ b/__tests__/fixtures/invalid.js
@@ -1,0 +1,40 @@
+// Each construct in this file trips exactly one rule that our config turns on
+// or reconfigures. The test asserts the exact set of rules that fire, so both
+// adding and losing a rule will fail it.
+//
+// Fixtures are excluded from Prettier so that reformatting can never silently
+// change which rules fire.
+
+// `n/file-extension-in-import` is set to 'always'.
+import { sibling } from './sibling';
+
+// `no-var`
+var legacy = 1;
+
+// `object-shorthand`
+export const wrapped = { legacy: legacy };
+
+// `prefer-template`
+export const greeting = 'hello ' + legacy;
+
+// `no-return-assign` — parenthesised assignments are allowed, bare ones are not.
+export function assign(target) {
+	return target.count = legacy;
+}
+
+// lowercase sentence comments trip `capitalized-comments`
+export const flagged = sibling.length;
+
+// `@cloudfour/prefer-early-return` — more than two statements under a lone `if`.
+export function guard(value) {
+	if (value) {
+		console.log(value);
+		console.log(legacy);
+		console.log(sibling);
+	}
+}
+
+// `no-unused-expressions` runs with `allowShortCircuit: false`.
+export function shortCircuit(value) {
+	value && console.log(value);
+}

--- a/__tests__/fixtures/invalid.ts
+++ b/__tests__/fixtures/invalid.ts
@@ -1,0 +1,26 @@
+// Each construct in this file trips exactly one rule that our TypeScript
+// overrides turn on or reconfigure. The test asserts the exact set of rules
+// that fire, so both adding and losing a rule will fail it.
+//
+// Fixtures are excluded from Prettier so that reformatting can never silently
+// change which rules fire.
+
+// `@typescript-eslint/consistent-type-imports` — Config is only used as a type.
+// `import/no-duplicates` with `prefer-inline` — these should be one statement.
+import { Config } from './types.js';
+import { VERSION } from './types.js';
+
+// `@typescript-eslint/array-type` is set to `array`, so this should be `string[]`.
+export const names: Array<string> = [];
+
+// `@typescript-eslint/no-non-null-assertion` is an error for us, not a warning.
+export const shout = (config: Config | undefined) => config!.name;
+
+// `@typescript-eslint/no-unnecessary-boolean-literal-compare`
+export const isReady = (ready: boolean) => ready === true;
+
+// `@typescript-eslint/prefer-optional-chain`
+export const nameOf = (config: Config | undefined) => config && config.name;
+
+// `@typescript-eslint/no-unnecessary-condition` — VERSION is never undefined.
+export const hasVersion = VERSION !== undefined;

--- a/__tests__/fixtures/sibling.js
+++ b/__tests__/fixtures/sibling.js
@@ -1,0 +1,3 @@
+// Import target for the `n/file-extension-in-import` case in invalid.js.
+// It has to resolve, otherwise `n/no-missing-import` fires first and masks it.
+export const sibling = 'sibling';

--- a/__tests__/fixtures/types.ts
+++ b/__tests__/fixtures/types.ts
@@ -1,0 +1,4 @@
+// Import target for the type-import cases in the TypeScript fixtures.
+export type Config = { name: string };
+
+export const VERSION = 1;

--- a/__tests__/fixtures/valid.js
+++ b/__tests__/fixtures/valid.js
@@ -1,0 +1,42 @@
+// Every construct in this file is something our config deliberately allows,
+// usually because we explicitly turned a rule off. If a dependency upgrade
+// re-enables one of them, this fixture starts reporting and the test fails.
+//
+// Fixtures are excluded from Prettier so that reformatting can never silently
+// change which rules fire.
+
+// `unicorn/no-null` is off — null is a legitimate value.
+export const nothing = null;
+
+// `unicorn/prevent-abbreviations` is off.
+export const props = { i: 0, prev: nothing };
+
+// `no-param-reassign` is off.
+export const clamp = (value) => {
+	if (value < 0) value = 0;
+	return value;
+};
+
+// `unicorn/no-array-reduce` is off.
+export const sum = (numbers) => numbers.reduce((total, next) => total + next, 0);
+
+// `unicorn/no-array-callback-reference` is off.
+export const toNumbers = (strings) => strings.map(Number);
+
+// `unicorn/prefer-set-has` is off, so repeated `includes` on an array is fine.
+const allowed = ['a', 'b'];
+export const isAllowed = (value) => allowed.includes(value);
+
+// `unicorn/prefer-number-properties` runs with `checkInfinity: false`.
+export const limit = Infinity;
+
+// `func-names` is off, so an anonymous function expression is fine.
+export const noop = function () {};
+
+// `capitalized-comments` ignores our pragma list, and both `no-warning-comments`
+// and `unicorn/expiring-todo-comments` are off.
+// todo: this comment is allowed
+export const done = true;
+
+// `prefer-destructuring` runs with `array: false`, so index access is fine.
+export const first = (values) => values[0];

--- a/__tests__/fixtures/valid.ts
+++ b/__tests__/fixtures/valid.ts
@@ -1,0 +1,38 @@
+// Every construct in this file is something our TypeScript overrides
+// deliberately allow. If a dependency upgrade re-enables one of these rules,
+// this fixture starts reporting and the test fails.
+//
+// Fixtures are excluded from Prettier so that reformatting can never silently
+// change which rules fire.
+
+// `@typescript-eslint/no-explicit-any` is off — `any` is an escape hatch.
+export const parse = (input: any): any => input;
+
+// The `@typescript-eslint/no-unsafe-*` family is off, so `any` stays usable.
+export const callAnything = (value: any) => value.whatever();
+
+// `@typescript-eslint/restrict-template-expressions` is off.
+export const label = (value: any) => `value: ${value}`;
+
+// `@typescript-eslint/no-floating-promises` is off — humans decide when to catch.
+export const fireAndForget = (run: () => Promise<void>) => {
+	run();
+};
+
+// `no-unused-vars` and `@typescript-eslint/no-unused-vars` are both off,
+// because TypeScript reports these itself.
+export const withUnused = (used: string) => {
+	const unused = 1;
+	return used;
+};
+
+// `@typescript-eslint/no-empty-function` is off.
+export function empty() {}
+
+// `@typescript-eslint/no-confusing-void-expression` runs with
+// `ignoreArrowShorthand: true`.
+export const shorthandVoid = (run: () => void) => run();
+
+// `@typescript-eslint/explicit-module-boundary-types` is off, so an inferred
+// return type on an exported function is fine.
+export const inferred = (count: number) => count * 2;

--- a/__tests__/helpers.js
+++ b/__tests__/helpers.js
@@ -1,0 +1,51 @@
+import { ESLint } from 'eslint';
+
+import config from '../eslint.config.js';
+
+/**
+ * Lints a fixture with our published config.
+ *
+ * Fixtures go through the real `ESLint` class rather than `Linter` so that
+ * `files` patterns, `languageOptions` and the type-aware TypeScript overrides
+ * all resolve exactly the way they will for consumers. `overrideConfigFile:
+ * true` stops ESLint searching the filesystem for a config, so the array we
+ * export is the only thing under test.
+ *
+ * @param {string} filePath Fixture path, relative to the repo root.
+ * @returns {Promise<import('eslint').Linter.LintMessage[]>}
+ */
+export const lintFixture = async (filePath) => {
+	const eslint = new ESLint({
+		overrideConfigFile: true,
+		overrideConfig: config,
+	});
+
+	const [result] = await eslint.lintFiles(filePath);
+	return result.messages;
+};
+
+/**
+ * The set of rules a fixture tripped, sorted and de-duplicated.
+ *
+ * We assert on the set rather than on every individual message because what we
+ * care about is which rules are active, not how many times each one happened to
+ * fire. That keeps the fixtures editable without making the tests meaningless:
+ * adding or losing a rule still fails.
+ *
+ * @param {import('eslint').Linter.LintMessage[]} messages
+ * @returns {string[]}
+ */
+export const rulesFired = (messages) =>
+	[...new Set(messages.map((message) => message.ruleId))].toSorted();
+
+/**
+ * Renders messages as `line:column rule` for assertion failure output, so a
+ * failing test says what actually fired instead of just "not deep equal".
+ *
+ * @param {import('eslint').Linter.LintMessage[]} messages
+ * @returns {string}
+ */
+export const format = (messages) =>
+	messages
+		.map((message) => `${message.line}:${message.column} ${message.ruleId}`)
+		.join('\n');

--- a/__tests__/javascript.test.js
+++ b/__tests__/javascript.test.js
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { format, lintFixture, rulesFired } from './helpers.js';
+
+describe('JavaScript config', () => {
+	it('allows everything our overrides deliberately permit', async () => {
+		const messages = await lintFixture('__tests__/fixtures/valid.js');
+
+		assert.deepEqual(
+			rulesFired(messages),
+			[],
+			`Expected no rules to fire, got:\n${format(messages)}`,
+		);
+	});
+
+	it('flags exactly the rules we turn on or reconfigure', async () => {
+		const messages = await lintFixture('__tests__/fixtures/invalid.js');
+
+		assert.deepEqual(rulesFired(messages), [
+			'@cloudfour/prefer-early-return',
+			'capitalized-comments',
+			'n/file-extension-in-import',
+			'no-return-assign',
+			'no-unused-expressions',
+			'no-var',
+			'object-shorthand',
+			'prefer-template',
+		]);
+	});
+
+	it('reports at error severity rather than warning', async () => {
+		const messages = await lintFixture('__tests__/fixtures/invalid.js');
+		const severities = [
+			...new Set(messages.map((message) => message.severity)),
+		];
+
+		assert.deepEqual(severities, [2]);
+	});
+});

--- a/__tests__/prettier-conflicts.test.js
+++ b/__tests__/prettier-conflicts.test.js
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { describe, it } from 'node:test';
+
+// eslint-config-prettier ships a CLI that resolves our config for a file and
+// reports any enabled rule that conflicts with Prettier. Using it is better
+// than maintaining our own list: the list of conflicting rules lives upstream
+// and updates when we bump the dependency.
+//
+// This guards the `@stylistic/*` overrides at the bottom of eslint.config.js,
+// which were added by hand in 25.0.1 after conflicts were found manually.
+const checkPrettierConflicts = (filePath) => {
+	try {
+		execFileSync(
+			process.execPath,
+			['node_modules/eslint-config-prettier/bin/cli.js', filePath],
+			{ encoding: 'utf8', stdio: 'pipe' },
+		);
+		return null;
+	} catch (error) {
+		return error.stdout || error.message;
+	}
+};
+
+describe('Prettier compatibility', () => {
+	// One case per config branch: the base config, and the TypeScript overrides.
+	for (const filePath of [
+		'__tests__/fixtures/valid.js',
+		'__tests__/fixtures/valid.ts',
+	]) {
+		it(`enables no rules that conflict with Prettier for ${filePath}`, () => {
+			assert.equal(checkPrettierConflicts(filePath), null);
+		});
+	}
+});

--- a/__tests__/typescript.test.js
+++ b/__tests__/typescript.test.js
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { format, lintFixture, rulesFired } from './helpers.js';
+
+// These fixtures exercise the type-aware half of the config, so they depend on
+// `tsconfig.json` at the repo root — that is what typescript-eslint's
+// `projectService` resolves them against.
+describe('TypeScript config', () => {
+	it('allows everything our TypeScript overrides deliberately permit', async () => {
+		const messages = await lintFixture('__tests__/fixtures/valid.ts');
+
+		assert.deepEqual(
+			rulesFired(messages),
+			[],
+			`Expected no rules to fire, got:\n${format(messages)}`,
+		);
+	});
+
+	it('flags exactly the rules we turn on or reconfigure', async () => {
+		const messages = await lintFixture('__tests__/fixtures/invalid.ts');
+
+		assert.deepEqual(rulesFired(messages), [
+			'@typescript-eslint/array-type',
+			'@typescript-eslint/consistent-type-imports',
+			'@typescript-eslint/no-non-null-assertion',
+			'@typescript-eslint/no-unnecessary-boolean-literal-compare',
+			'@typescript-eslint/no-unnecessary-condition',
+			'@typescript-eslint/prefer-optional-chain',
+			'import/no-duplicates',
+		]);
+	});
+
+	it('keeps type-aware rules enabled, which need real type information', async () => {
+		const messages = await lintFixture('__tests__/fixtures/invalid.ts');
+
+		// `no-unnecessary-condition` can only fire when the project service
+		// resolved types. If tsconfig.json or `projectService` ever breaks, the
+		// rule silently stops reporting instead of erroring, so assert it here.
+		assert.ok(
+			messages.some(
+				(message) =>
+					message.ruleId === '@typescript-eslint/no-unnecessary-condition',
+			),
+			`Type information was not available. Rules that fired:\n${format(messages)}`,
+		);
+	});
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,9 @@
 			},
 			"devDependencies": {
 				"eslint": "9.39.5",
-				"prettier": "3.9.6"
+				"prettier": "3.9.6",
+				"semver": "7.7.4",
+				"typescript": "5.6.3"
 			},
 			"engines": {
 				"node": ">=22.16.0"
@@ -3728,7 +3730,7 @@
 			"version": "5.6.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
 			"integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
-			"peer": true,
+			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -8,12 +8,16 @@
 	"license": "MIT",
 	"main": "./eslint.config.js",
 	"type": "module",
+	"files": [
+		"eslint.config.js",
+		"src"
+	],
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/cloudfour/eslint-config.git"
 	},
 	"engines": {
-		"node": ">=22.16.0"
+		"node": "^22.16.0 || >=24"
 	},
 	"keywords": [
 		"eslint",
@@ -24,15 +28,19 @@
 	},
 	"devDependencies": {
 		"eslint": "9.39.5",
-		"prettier": "3.9.6"
+		"prettier": "3.9.6",
+		"semver": "7.7.4",
+		"typescript": "5.6.3"
 	},
 	"scripts": {
 		"lint": "npm run lint:js && npm run lint:prettier",
 		"lint:check": "npm run lint:js:check && npm run lint:prettier:check",
-		"lint:js": "eslint --fix .",
-		"lint:js:check": "eslint .",
+		"lint:js": "eslint --fix . --ignore-pattern \"__tests__/fixtures/**\"",
+		"lint:js:check": "eslint . --ignore-pattern \"__tests__/fixtures/**\"",
 		"lint:prettier": "prettier --write .",
-		"lint:prettier:check": "prettier --check ."
+		"lint:prettier:check": "prettier --check .",
+		"test": "node --test",
+		"test:watch": "node --test --watch"
 	},
 	"prettier": {
 		"singleQuote": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"//": "Exists so typescript-eslint's `projectService` can type-check the test fixtures. Nothing is compiled from it.",
+	"compilerOptions": {
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
+		"target": "esnext",
+		"strict": true,
+		"noEmit": true
+	},
+	"include": ["__tests__/fixtures/**/*.ts"]
+}


### PR DESCRIPTION
## Overview

CI on this repo runs `eslint .` against its own three source files. That tells us the config **loads**; it tells us nothing about whether it still **behaves** the same way. With a backlog of major-version Renovate PRs waiting (#680, #692, #695, #696) — `eslint-plugin-unicorn` v63 → v73 alone crosses 300+ rules and several renames — "CI is green" is a much weaker claim than we want before cutting a major release. This adds a `node --test` suite so a dependency bump produces a readable diff of what actually changed, which is also the raw material the changelog entries need.

The fixtures are split into `valid` and `invalid` pairs, and the `valid` half is the interesting one. Rather than generic clean code, every construct in it is something the config deliberately allows — `null`, abbreviations, `reduce`, parameter reassignment, `any`, floating promises. Those are the cases a passing lint run structurally cannot detect: if a dependency re-enables a rule we turned off, nothing today would tell us until a consumer hit it.

This also narrows `engines.node` from `>=22.16.0` to `^22.16.0 || >=24`, which makes the release breaking. That is not a change I went looking for — the new `engines` test failed on `main`, before any upgrade. `eslint-plugin-jsdoc@62.9.0`, the version currently pinned, declares `^20.19.0 || ^22.13.0 || >=24`, so the range we advertise has always included a Node version it excludes. It is the same Node 23 gap that is currently failing #680. The fix and the test have to land together: the test cannot pass without the fix, and the fix looks arbitrary without the test.

One deliberate omission: there are no tests lifted from upstream. Unlike `stylelint-config-cloudfour`, where the bundled configs ship transferable fixture tests, our dependencies either test their own composition (`eslint-config-xo`, `neostandard`) or test rules in isolation via `RuleTester` (the plugins) — neither says anything about our overrides. The one upstream check that does transfer is the `eslint-config-prettier` CLI, which is wired in as a test; it keeps the list of Prettier-conflicting rules upstream where it updates on its own.

A `files` field is added alongside, because without it the published tarball would have picked up `__tests__/` and `tsconfig.json`. It was already shipping `.editorconfig`, `.nvmrc`, `.renovaterc.json` and the CI workflow.

## Screenshots

## Testing

CI already runs the suite, so there is no need to check that it passes. What is worth verifying manually is that the tests are **meaningful** — that they fail when the config's behavior actually changes. Each step below breaks something on purpose; undo it before moving to the next.

- [ ] Run `npm ci`, then `npm test`. All 24 tests should pass.
- [ ] In `eslint.config.js`, find `'unicorn/no-null': 'off'` and change it to `'error'`. Run `npm test` — exactly one test should fail, the JavaScript "allows everything our overrides deliberately permit" test, and the failure message should list `unicorn/no-null` as the rule that fired. Change it back.
- [ ] In `eslint.config.js`, find `'no-var': 'error'` and change it to `'off'`. Run `npm test` — exactly one test should fail, the JavaScript "flags exactly the rules we turn on or reconfigure" test, showing `no-var` missing from the expected list. Change it back.
- [ ] Rename `tsconfig.json` to something else. Run `npm test` — three TypeScript tests should fail, one of them saying "Type information was not available". This is the case worth seeing: without the tests, losing type-aware linting makes rules go quiet rather than raising an error. Rename it back.
- [ ] In `package.json`, change `engines.node` back to `>=22.16.0`. Run `npm test` — one test should fail, naming `eslint-plugin-jsdoc` and explaining that we claim support for Node versions it does not have. Change it back.
- [ ] Run `npm pack --dry-run`. The tarball should contain 7 files: the license, readme, `eslint.config.js`, `package.json`, and the three files under `src/`. No test files, no `tsconfig.json`, no repo config files.

Closes #698
