### PR TITLE
Update typescript to v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
 				"eslint": "10.9.1",
 				"prettier": "3.9.6",
 				"semver": "7.8.5",
-				"typescript": "5.9.3"
+				"typescript": "6.0.3"
 			},
 			"engines": {
 				"node": "^22.22.2 || >=24.15.0"
@@ -2452,9 +2452,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.9.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
 			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"eslint": "10.9.1",
 		"prettier": "3.9.6",
 		"semver": "7.8.5",
-		"typescript": "5.9.3"
+		"typescript": "6.0.3"
 	},
 	"scripts": {
 		"lint": "npm run lint:js && npm run lint:prettier",


### PR DESCRIPTION
## Overview

Renovate offered TypeScript 7 in #703 and skipped 6 entirely, because it proposes the latest major rather than the latest supported one. TypeScript 7 ships no programmatic API, so `typescript-eslint` caps its peer range at `<6.1.0` and cannot support it — #703 is closed with the detail. That left us sitting on `5.9.3` when `6.0.3` is available and inside the supported range.

`typescript` is a devDependency here purely so `typescript-eslint`'s `projectService` can type-check the fixtures in `__tests__/`. We do not compile anything, and the published config is unchanged, so there is no changelog entry and no consumer impact.

## Screenshots

## Testing

CI covers this. The type-aware fixtures are the thing a compiler bump could plausibly disturb, and they pass unchanged on both ESLint 10.9.1 and the 9.38.0 floor.

- [ ] Nothing to verify by hand.
